### PR TITLE
+build constraint for convert_unix.go

### DIFF
--- a/convert_unix.go
+++ b/convert_unix.go
@@ -1,3 +1,5 @@
+// +build darwin freebsd linux netbsd openbsd
+
 package flags
 
 import (


### PR DESCRIPTION
The package won't compile under Windows because the convert_unix.go file is included.

```
# github.com/jessevdk/go-flags
..\..\..\..\github.com\jessevdk\go-flags\convert_unix.go:16: undefined: syscall.SYS_IOCTL
..\..\..\..\github.com\jessevdk\go-flags\convert_unix.go:19: not enough arguments in call to syscall.Syscall
..\..\..\..\github.com\jessevdk\go-flags\convert_windows.go:3: getTerminalColumns redeclared in this block
        previous declaration at ..\..\..\..\github.com\jessevdk\go-flags\convert_unix.go:13
```

See http://golang.org/pkg/go/build/
