### PR TITLE
Terminal Columns aren't always available

### DIFF
--- a/help.go
+++ b/help.go
@@ -109,6 +109,9 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 	maxlen := maxlonglen + 4
 
 	termcol := getTerminalColumns()
+	if termcol <= 0 {
+		termcol = 80
+	}
 
 	for _, grp := range p.Groups {
 		wr.WriteString("\n")


### PR DESCRIPTION
In my case (OS X 10.8.2 + iTerm2) `getTerminalColumns()` returns always `0`.

This is a simple change to make it safer and assume `80` when a better value isn't available. Most unix tools do something similar.
