### PR TITLE
Add documentation of the 'required' field tag to the package comment.

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -41,6 +41,7 @@
 //     long:        the long name of the option
 //     description: the description of the option (optional)
 //     optional:    whether an argument of the option is optional (optional)
+//	   required:	whether an argument of the option is required (optional)
 //     default:     the default argument value if the option occurs without
 //                  an argument (optional)
 //     base:        a base used to convert strings to integer values (optional)


### PR DESCRIPTION
Hello,

Been enjoying using your library, I've found it quite useful.

I just noticed that there's actually a "required" field tag option; not sure why it's used slightly inconsistantly with `OptionalArgument`, but I figured it could be documented.

Happy to go through and make these consistent if you like.. I suppose they should just resolve to the same option, with one being the inverse of the other?
