### PR TITLE
time.Duration issue

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -86,6 +86,7 @@ func convert(val string, retval reflect.Value, options reflect.StructTag) error 
 		}
 
 		retval.SetInt(int64(parsed))
+		return nil
 	}
 
 	switch tp.Kind() {


### PR DESCRIPTION
I couldn't get parsing of a time.Duration to work until I added a nil return to convert.go to avoid further parse logic.
It looks like the code was continuing to parse (because tp.Kind() of a time.Duration is int64) even after it had successfully parsed the time.Duration.

Adding the return made it work, and my code got a time.Duration as a result of option parsing.

```
diff --git a/convert.go b/convert.go
index ca3aebd..287c691 100644
--- a/convert.go
+++ b/convert.go
@@ -80,12 +80,12 @@ func convert(val string, retval reflect.Value, options refle
        // Support for time.Duration
        if tp == reflect.TypeOf((*time.Duration)(nil)).Elem() {
                parsed, err := time.ParseDuration(val)
-
                if err != nil {
                        return err
                }

                retval.SetInt(int64(parsed))
+               return nil
        }

        switch tp.Kind() {
```
