### PR TITLE
add parse command

### DIFF
--- a/help.go
+++ b/help.go
@@ -32,7 +32,7 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 		ret.terminalColumns = 80
 	}
 
-	p.EachGroup(func(index int, grp *Group) {
+	p.EachGroupWithTopLevel(func(index int, grp *Group) {
 		for _, info := range grp.Options {
 			if info.ShortName != 0 {
 				ret.hasShort = true

--- a/parser.go
+++ b/parser.go
@@ -193,6 +193,13 @@ func (p *Parser) EachGroup(cb func(int, *Group)) {
 	}
 }
 
+func (p *Parser) EachGroupWithTopLevel(cb func(int, *Group)) {
+	if p.currentCommand != nil {
+		p.currentCommand.each(0, cb)
+	}
+	p.eachTopLevelGroup(cb)
+}
+
 // ParseIni parses flags from an ini format. You can use ParseIniFile as a
 // convenience function to parse from a filename instead of a general
 // io.Reader.

--- a/parser_private.go
+++ b/parser_private.go
@@ -10,6 +10,9 @@ func (p *Parser) storeDefaults() {
 	p.EachGroup(func(index int, grp *Group) {
 		grp.storeDefaults()
 	})
+	p.Commander.EachCommand(func(command string, grp *Group) {
+		grp.storeDefaults()
+	})
 }
 
 func (p *Parser) parseOption(group *Group, args []string, name string, option *Option, canarg bool, argument *string, index int) (error, int, *Option) {


### PR DESCRIPTION
Support such usage

./a.out hello -h       flags are: hello -h

Pass all arguments after a normal argument occurs
