### PR TITLE
Support Windows-style options.

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -26,6 +26,7 @@
 // Additional features specific to Windows:
 //     Options with short names (/v)
 //     Options with long names (/verbose)
+//     Windows-style options with arguments use a colon as the delimiter
 //     Modify generated help message with Windows-style / options
 //
 // The flags package uses structs, reflection and struct field tags

--- a/help.go
+++ b/help.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"runtime"
 	"strings"
 	"unicode/utf8"
 )
@@ -74,11 +73,7 @@ func (p *Parser) writeHelpOption(writer *bufio.Writer, option *Option, info alig
 	line.WriteString(strings.Repeat(" ", paddingBeforeOption))
 
 	if option.ShortName != 0 {
-		if runtime.GOOS == "windows" {
-			line.WriteString("/")
-		} else {
-			line.WriteString("-")
-		}
+		line.WriteRune(defaultShortOptDelimiter)
 		line.WriteRune(option.ShortName)
 	} else if info.hasShort {
 		line.WriteString("  ")
@@ -105,17 +100,12 @@ func (p *Parser) writeHelpOption(writer *bufio.Writer, option *Option, info alig
 			line.WriteString("  ")
 		}
 
-		if runtime.GOOS == "windows" {
-			line.WriteString("/")
-		} else {
-			line.WriteString("--")
-		}
-
+		line.WriteString(defaultLongOptDelimiter)
 		line.WriteString(option.LongName)
 	}
 
 	if !option.isBool() {
-		line.WriteString("=")
+		line.WriteRune(defaultNameArgDelimiter)
 
 		if len(option.ValueName) > 0 {
 			line.WriteString(option.ValueName)

--- a/optstyle_other.go
+++ b/optstyle_other.go
@@ -1,0 +1,50 @@
+// +build !windows
+
+package flags
+
+import (
+	"strings"
+)
+
+const (
+	defaultShortOptDelimiter = '-'
+	defaultLongOptDelimiter  = "--"
+	defaultNameArgDelimiter  = '='
+)
+
+func argumentIsOption(arg string) bool {
+	return len(arg) > 0 && arg[0] == '-'
+}
+
+// stripOptionPrefix returns the option without the prefix and whether or
+// not the option is a long option or not.
+func stripOptionPrefix(optname string) (string, bool) {
+	if strings.HasPrefix(optname, "--") {
+		return optname[2:], true
+	} else if strings.HasPrefix(optname, "-") {
+		return optname[1:], false
+	}
+
+	return optname, false
+}
+
+// splitOption attempts to split the passed option into a name and an argument.
+// When there is no argument specified, nil will be returned for it.
+func splitOption(option string) (string, *string) {
+	pos := strings.Index(option, "=")
+	if pos >= 0 {
+		rest := option[pos+1:]
+		return option[:pos], &rest
+	}
+
+	return option, nil
+}
+
+// newHelpGroup returns a new group that contains default help parameters.
+func newHelpGroup(showHelp func() error) *Group {
+	var help struct {
+		ShowHelp func() error `short:"h" long:"help" description:"Show this help message"`
+	}
+	help.ShowHelp = showHelp
+	return NewGroup("Help Options", &help)
+}

--- a/optstyle_windows.go
+++ b/optstyle_windows.go
@@ -1,0 +1,80 @@
+package flags
+
+import (
+	"strings"
+)
+
+// Windows uses a front slash for both short and long options.  Also it uses
+// a colon for name/argument delimter.
+const (
+	defaultShortOptDelimiter = '/'
+	defaultLongOptDelimiter  = "/"
+	defaultNameArgDelimiter  = ':'
+)
+
+func argumentIsOption(arg string) bool {
+	// Windows-style options allow front slash for the option
+	// delimiter.
+	return len(arg) > 0 && (arg[0] == '-' || arg[0] == '/')
+}
+
+// stripOptionPrefix returns the option without the prefix and whether or
+// not the option is a long option or not.
+func stripOptionPrefix(optname string) (string, bool) {
+	// Determine if the argument is a long option or not.  Windows
+	// typically supports both long and short options with a single
+	// front slash as the option delimiter, so handle this situation
+	// nicely.
+	if strings.HasPrefix(optname, "--") {
+		return optname[2:], true
+	} else if strings.HasPrefix(optname, "-") {
+		return optname[1:], false
+	} else if strings.HasPrefix(optname, "/") {
+		optname = optname[1:]
+		if len(optname) > 1 {
+			return optname, true
+		}
+		return optname, false
+	}
+
+	return optname, false
+}
+
+// splitOption attempts to split the passed option into a name and an argument.
+// When there is no argument specified, nil will be returned for it.
+func splitOption(option string) (string, *string) {
+	if len(option) == 0 {
+		return option, nil
+	}
+
+	// Windows typically uses a colon for the option name and argument
+	// delimiter while POSIX typically uses an equals.  Support both styles,
+	// but don't allow the two to be mixed.  That is to say /foo:bar and
+	// --foo=bar are acceptable, but /foo=bar and --foo:bar are not.
+	var pos int
+	if option[0] == '/' {
+		pos = strings.Index(option, ":")
+	} else if option[0] == '-' {
+		pos = strings.Index(option, "=")
+	}
+
+	if pos >= 0 {
+		rest := option[pos+1:]
+		return option[:pos], &rest
+	}
+
+	return option, nil
+}
+
+// newHelpGroup returns a new group that contains default help parameters.
+func newHelpGroup(showHelp func() error) *Group {
+	// Windows CLI applications typically use /? for help, so make both
+	// that available as well as the POSIX style h and help.
+	var help struct {
+		ShowHelp  func() error `short:"?" description:"Show this help message"`
+		ShowHelp2 func() error `short:"h" long:"help" description:"Show this help message"`
+	}
+	help.ShowHelp = showHelp
+	help.ShowHelp2 = showHelp
+	return NewGroup("Help Options", &help)
+}


### PR DESCRIPTION
This commit adds support for front slash to be used for options on Windows.

Front slashes are the standard style for Windows CLI programs.  Also,
Windows doesn't typically differentiate between short and long options
because a front slash works for both.  Finally, Windows CLI applications
typically support /? for help.

So given the above, this commit makes the following modifications only
when running on Windows:
- Adds support for Windows-style options with short names (/v)
- Adds support for Windows-style options with long names (/verbose)
- Adds an additional Windows-style help entry (/?)
- Modifies the help (usage) display to show Windows-style options
  (example: /v for short names, /verbose for long names)
- Note that in all cases the unix style -, and -- still work as well
  on Windows for consistency among operating systems.

Finally, the documentation has been updated to reflect the new
capabilities.
