### PR TITLE
Add IgnoreDefaults option to allow the parser to avoid storing defaults

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -72,7 +72,9 @@ func IniParse(filename string, data interface{}) error {
 // information on the ini file foramt. The returned errors can be of the type
 // flags.Error or flags.IniError.
 func (i *IniParser) ParseFile(filename string) error {
-	i.parser.storeDefaults()
+	if (i.parser.Options & IgnoreDefaults) == None {
+		i.parser.storeDefaults()
+	}
 
 	ini, err := readIniFromFile(filename)
 
@@ -109,7 +111,9 @@ func (i *IniParser) ParseFile(filename string) error {
 // The returned errors can be of the type flags.Error or
 // flags.IniError.
 func (i *IniParser) Parse(reader io.Reader) error {
-	i.parser.storeDefaults()
+	if (i.parser.Options & IgnoreDefaults) == None {
+		i.parser.storeDefaults()
+	}
 
 	ini, err := readIni(reader, "")
 

--- a/parser.go
+++ b/parser.go
@@ -57,6 +57,12 @@ const (
 	// POSIX processing.
 	PassAfterNonOption
 
+	// IgnoreDefaults will skip assigning default values. This may be useful
+	// in cases that require knowledge of options that were actually passed in
+	// -- for example, when merging options from the command line with options
+	// from a config file.
+	IgnoreDefaults
+
 	// Default is a convenient default set of options which should cover
 	// most of the uses of the flags package.
 	Default = HelpFlag | PrintErrors | PassDoubleDash
@@ -127,11 +133,13 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 		return nil, p.internalError
 	}
 
-	p.eachCommand(func(c *Command) {
-		c.eachGroup(func(g *Group) {
-			g.storeDefaults()
-		})
-	}, true)
+	if (p.Options & IgnoreDefaults) == None {
+		p.eachCommand(func(c *Command) {
+			c.eachGroup(func(g *Group) {
+				g.storeDefaults()
+			})
+		}, true)
+	}
 
 	// Add builtin help group to all commands if necessary
 	if (p.Options & HelpFlag) != None {


### PR DESCRIPTION
I needed the defaults to be included when writing out the help text, and they needed to be applied, but _after_ values had been filled in from another source. That is, priority was Command Line > Config File > Defaults. The only way I could figure out how to accomplish this was to parse with no arguments (to get the defaults struct), parse the command line options (with the IgnoreDefaults parser option provided by this pull request), parse the config file (using an option from the command line that specified config file path), then merge the structs in the correct order. Without IgnoreDefaults, I would have no way of knowing what got parsed and what was a default.

Maybe there's a better way to do this, but it's working well for me.
