### PR TITLE
Added flags.Help and flags.PrintHelp methods

### DIFF
--- a/error.go
+++ b/error.go
@@ -51,6 +51,9 @@ const (
 
 	// ErrUnknownCommand indicates that an unknown command was specified.
 	ErrUnknownCommand
+
+	// ErrArgumentsNoParsed indicates that the command line arguments have not been parsed.	
+	ErrArgumentsNoParsed
 )
 
 // Error represents a parser error. The error returned from Parse is of this

--- a/help.go
+++ b/help.go
@@ -190,6 +190,31 @@ func maxCommandLength(s []*Command) int {
 	return ret
 }
 
+// Help returns the help message as a string. You must call one of the flags.Parse
+// method before calling this method. An error ErrArgumentsNoParsed is
+// returned if the arguments have not been parsed yet.
+func Help() (string, error) {
+	if defaultParser == nil {
+		return "", newError(ErrArgumentsNoParsed, "arguments have not been parsed")
+	}
+	
+	var b bytes.Buffer
+	defaultParser.WriteHelp(&b)
+	return b.String(), nil
+}
+
+// PrintHelp is a helper function that prints the help message to stdout. You
+// must call one of the flags.Parse methods before calling this function.
+func PrintHelp() error {
+	help, err := Help()
+	if err != nil {
+		return err
+	}
+	
+	fmt.Println(help)
+	return nil
+}
+
 // WriteHelp writes a help message containing all the possible options and
 // their descriptions to the provided writer. Note that the HelpFlag parser
 // option provides a convenient way to add a -h/--help option group to the

--- a/help_test.go
+++ b/help_test.go
@@ -212,3 +212,31 @@ Help Options:
 		}
 	}
 }
+
+func TestPrintHelp(t *testing.T) {	
+	var opts struct {
+		Testing bool `short:"t" long:"testing" description:"Testing."`
+	}
+
+	defaultParser = nil
+
+	_, err := Help()
+	if err == nil {
+		t.Errorf("Expected an error, got nil")
+	} else {
+		if err.(*Error).Type != ErrArgumentsNoParsed {
+			t.Errorf("Expected ErrArgumentsNoParsed, got %s", err.(*Error).Type)
+		}
+	}
+
+	Parse(&opts)
+	s, err := Help()
+
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err)		
+	}
+	
+	if s == "" {
+		t.Errorf("Expected help string, got empty string")
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -67,7 +67,8 @@ const (
 // default option group (named "Application Options"). For more control, use
 // flags.NewParser.
 func Parse(data interface{}) ([]string, error) {
-	return NewParser(data, Default).Parse()
+	defaultParser = NewParser(data, Default)
+	return defaultParser.Parse()
 }
 
 // ParseArgs is a convenience function to parse command line options with default
@@ -77,7 +78,8 @@ func Parse(data interface{}) ([]string, error) {
 // default program command line arguments (i.e. os.Args), then use flags.Parse
 // instead. For more control, use flags.NewParser.
 func ParseArgs(data interface{}, args []string) ([]string, error) {
-	return NewParser(data, Default).ParseArgs(args)
+	defaultParser = NewParser(data, Default)
+	return defaultParser.ParseArgs(args)
 }
 
 // NewParser creates a new parser. It uses os.Args[0] as the application

--- a/parser_private.go
+++ b/parser_private.go
@@ -8,6 +8,8 @@ import (
 	"unicode/utf8"
 )
 
+var defaultParser *Parser = nil
+
 type parseState struct {
 	arg     string
 	args    []string


### PR DESCRIPTION
This pull request adds two helper methods: `flags.Help()` and `flags.PrintHelp()`. The first one returns the help message as a string, while the second one prints it directly to stdout (similar to `flag.PrintDefault()` from the standard package). `flags.Parse` or `flags.ParseArgs` must be called before calling any of these two new methods.

Since go-flags did not keep track of the parser created by `flag.Parse` (since it wasn't needed), I've added a new `defaultParser` variable which will hold the last parser created by these two functions.
