### PR TITLE
Fixed ini file parser to read lines starting with # as comments

### DIFF
--- a/ini_private.go
+++ b/ini_private.go
@@ -198,8 +198,8 @@ func readIni(contents io.Reader, filename string) (ini, error) {
 		lineno++
 		line = strings.TrimSpace(line)
 
-		// Skip empty lines and lines starting with ; (comments)
-		if len(line) == 0 || line[0] == ';' {
+		// Skip empty lines and lines starting with ; or # (comments)
+		if len(line) == 0 || line[0] == ';' || line[0] == '#' {
 			continue
 		}
 


### PR DESCRIPTION
Hi,
We're using go-flags to read config files, and it's standard practice to start comments with #. 

I've added this tiny patch to support it, would appreciate you merging it so we won't need to use a fork :)

Thanks,
Dvir
