### PR TITLE
Some field tags are undocumented

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -60,15 +60,15 @@
 // and Unmarshaler interfaces.
 //
 // Available field tags:
-//     short:       the short name of the option (single character)
-//     long:        the long name of the option
-//     required:    whether an option is required to appear on the command line.
-//                  If a required option is not present, the parser will return
-//                  ErrRequired (optional)
-//     description: the description of the option (optional)
+//     short:            the short name of the option (single character)
+//     long:             the long name of the option
+//     required:         whether an option is required to appear on the command
+//                       line. If a required option is not present, the parser will
+//                       return ErrRequired (optional)
+//     description:      the description of the option (optional)
 //     long-description: the long description of the option. Currently only
 //                       displayed in generated man pages (optional)
-//     no-flag:     if non-empty this field is ignored as an option (optional)
+//     no-flag:          if non-empty this field is ignored as an option (optional)
 //
 //     optional:       whether an argument of the option is optional (optional)
 //     optional-value: the value of an optional option when the option occurs


### PR DESCRIPTION
(Sorry for closing the last pull request https://github.com/jessevdk/go-flags/pull/60 I could not figure out how to make two clean branches with the commits of the master branch)

The field tags long-description, no-flag, ini-name and no-ini are undocumented.

"_read-ini-name" is another tag I found to be undocumented but it looks like an internal temporary value.
