### PR TITLE
empty descriptions should not leave any output

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -41,9 +41,10 @@ func helpDiff(a, b string) (string, error) {
 }
 
 type helpOptions struct {
-	Verbose  []bool       `short:"v" long:"verbose" description:"Show verbose debug information" ini-name:"verbose"`
-	Call     func(string) `short:"c" description:"Call phone number" ini-name:"call"`
-	PtrSlice []*string    `long:"ptrslice" description:"A slice of pointers to string"`
+	Verbose          []bool       `short:"v" long:"verbose" description:"Show verbose debug information" ini-name:"verbose"`
+	Call             func(string) `short:"c" description:"Call phone number" ini-name:"call"`
+	PtrSlice         []*string    `long:"ptrslice" description:"A slice of pointers to string"`
+	EmptyDescription bool         `long:"empty-description"`
 
 	OnlyIni string `ini-name:"only-ini" description:"Option only available in ini"`
 
@@ -80,16 +81,17 @@ func TestHelp(t *testing.T) {
   TestHelp [OPTIONS] <command>
 
 Application Options:
-  -v, --verbose   Show verbose debug information
-  -c=             Call phone number
-      --ptrslice= A slice of pointers to string
+  -v, --verbose            Show verbose debug information
+  -c=                      Call phone number
+      --ptrslice=          A slice of pointers to string
+      --empty-description
 
 Other Options:
-  -s=             A slice of strings
-      --intmap=   A map from string to int
+  -s=                      A slice of strings
+      --intmap=            A map from string to int
 
 Help Options:
-  -h, --help      Show this help message
+  -h, --help               Show this help message
 
 Available commands:
   command  A command
@@ -142,6 +144,8 @@ Call phone number
 .TP
 \fB--ptrslice\fP
 A slice of pointers to string
+.TP
+\fB--empty-description\fP
 .TP
 \fB-s\fP
 A slice of strings

--- a/ini_private.go
+++ b/ini_private.go
@@ -90,7 +90,7 @@ func writeGroupIni(group *Group, namespace string, writer io.Writer, options Ini
 			sectionwritten = true
 		}
 
-		if comments {
+		if comments && len(option.Description) != 0 {
 			fmt.Fprintf(writer, "; %s\n", option.Description)
 		}
 

--- a/ini_test.go
+++ b/ini_test.go
@@ -32,6 +32,8 @@ verbose = true
 ; A slice of pointers to string
 ; PtrSlice =
 
+EmptyDescription = false
+
 ; Option only available in ini
 only-ini =
 

--- a/man.go
+++ b/man.go
@@ -54,8 +54,10 @@ func writeManPageOptions(wr io.Writer, grp *Group) {
 			}
 
 			fmt.Fprintln(wr, "\\fP")
-			formatForMan(wr, opt.Description)
-			fmt.Fprintln(wr, "")
+			if len(opt.Description) != 0 {
+				formatForMan(wr, opt.Description)
+				fmt.Fprintln(wr, "")
+			}
 		}
 	})
 }


### PR DESCRIPTION
If the optional description tag for a field is omitted, there are still traces of an empty description in the outputs of the man page and ini config. E.g. "; " for the ini config.
