### PR TITLE
Check for required options after argument parsing

### DIFF
--- a/command_private.go
+++ b/command_private.go
@@ -11,7 +11,6 @@ type lookup struct {
 	shortNames map[string]*Option
 	longNames  map[string]*Option
 
-	required map[*Option]bool
 	commands map[string]*Command
 }
 
@@ -105,16 +104,11 @@ func (c *Command) makeLookup() lookup {
 		shortNames: make(map[string]*Option),
 		longNames:  make(map[string]*Option),
 
-		required: make(map[*Option]bool),
 		commands: make(map[string]*Command),
 	}
 
 	c.eachGroup(func(g *Group) {
 		for _, option := range g.options {
-			if option.Required && option.canCli() {
-				ret.required[option] = true
-			}
-
 			if option.ShortName != 0 {
 				ret.shortNames[string(option.ShortName)] = option
 			}

--- a/ini_test.go
+++ b/ini_test.go
@@ -300,3 +300,75 @@ value = some value
 
 	assertError(t, err, ErrUnknownFlag, "unknown option: value")
 }
+
+func TestOverwriteRequiredOptions(t *testing.T) {
+	var tests = []struct {
+		args     []string
+		expected []string
+	}{
+		{
+			args: []string{"--value", "from CLI"},
+			expected: []string{
+				"from CLI",
+				"from default",
+			},
+		},
+		{
+			args: []string{"--value", "from CLI", "--default", "from CLI"},
+			expected: []string{
+				"from CLI",
+				"from CLI",
+			},
+		},
+		{
+			args: []string{"--config", "no file name"},
+			expected: []string{
+				"from INI",
+				"from INI",
+			},
+		},
+		{
+			args: []string{"--value", "from CLI before", "--default", "from CLI before", "--config", "no file name"},
+			expected: []string{
+				"from INI",
+				"from INI",
+			},
+		},
+		{
+			args: []string{"--value", "from CLI before", "--default", "from CLI before", "--config", "no file name", "--value", "from CLI after", "--default", "from CLI after"},
+			expected: []string{
+				"from CLI after",
+				"from CLI after",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var opts struct {
+			Config  func(s string) error `long:"config" no-ini:"true"`
+			Value   string               `long:"value" required:"true"`
+			Default string               `long:"default" required:"true" default:"from default"`
+		}
+
+		p := NewParser(&opts, Default)
+
+		opts.Config = func(s string) error {
+			ini := NewIniParser(p)
+
+			return ini.Parse(bytes.NewBufferString("value = from INI\ndefault = from INI"))
+		}
+
+		_, err := p.ParseArgs(test.args)
+		if err != nil {
+			t.Fatalf("Unexpected error %s with args %+v", err, test.args)
+		}
+
+		if opts.Value != test.expected[0] {
+			t.Fatalf("Expected Value to be \"%s\" but was \"%s\" with args %+v", test.expected[0], opts.Value, test.args)
+		}
+
+		if opts.Default != test.expected[1] {
+			t.Fatalf("Expected Default to be \"%s\" but was \"%s\" with args %+v", test.expected[1], opts.Default, test.args)
+		}
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -174,15 +174,14 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 		}
 
 		var err error
-		var options []*Option
 
 		prefix, optname, islong := stripOptionPrefix(arg)
 		optname, argument := splitOption(prefix, optname, islong)
 
 		if islong {
-			options, err = p.parseLong(s, optname, argument)
+			_, err = p.parseLong(s, optname, argument)
 		} else {
-			options, err = p.parseShort(s, optname, argument)
+			_, err = p.parseShort(s, optname, argument)
 		}
 
 		if err != nil {
@@ -196,10 +195,6 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 
 			if ignoreUnknown {
 				s.retargs = append(s.retargs, arg)
-			}
-		} else {
-			for _, option := range options {
-				delete(s.lookup.required, option)
 			}
 		}
 	}
@@ -226,7 +221,7 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 			})
 		}, true)
 
-		s.checkRequired()
+		s.err = p.checkRequired()
 	}
 
 	var reterr error


### PR DESCRIPTION
This surely looks odd at first but doing the required-checks after the argument parsing (not during) allows something pretty neat. Ini configs can overwrite default values of required options and there is no need for additional arguments for the options to pass the required-checks. The added test demonstrates the new behavior.

This pull request will also resolve (dummy space or else #42 would get automatically closed) #42 and #54. I will write examples for the issues when the request gets merged.

(Since I want to pass all tests with each commit, I had to remove some lines from parser.go because "options" was not used anymore. this will conflict with #73. I will rewrite the conflicting pull request of course when one gets merged)
