### PR TITLE
PassDoubleDash is required for completion

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -226,6 +226,8 @@ calls the binary which supports go-flags completion:
 
     complete -F _completion_example completion-example
 
+Completion requires the parser option PassDoubleDash and is therefore enforced if the environment variable GO_FLAGS_COMPLETION is set.
+
 Customized completion for argument values is supported by implementing
 the flags.Completer interface for the argument value type. An example
 of a type which does so is the flags.Filename type, an alias of string

--- a/parser.go
+++ b/parser.go
@@ -119,6 +119,8 @@ func NewNamedParser(appname string, options Options) *Parser {
 
 	if len(os.Getenv("GO_FLAGS_COMPLETION")) != 0 {
 		p.AddCommand("__complete", "completion", "automatic flags completion", &completion{parser: p})
+
+		p.Options |= PassDoubleDash
 	}
 
 	return p


### PR DESCRIPTION
I think the requirement for PassDoubleDash should be noted in the bash completion documentation. At least it took me a while to realize it :-)
