### PR TITLE
add CommanderNoArgs interface

### DIFF
--- a/command.go
+++ b/command.go
@@ -39,6 +39,16 @@ type Commander interface {
 	Execute(args []string) error
 }
 
+// CommanderNoArgs is and interface like Commander, with the exception that it
+// does not accept any extra positional arguments and an error will be produced
+// before calling Execute(), if such arguments are given by the user.
+type CommanderNoArgs interface {
+	// Execute will be called for the last active (sub)command. The
+	// error that Execute returns will be eventually passed out of the
+	// Parse method of the Parser.
+	Execute() error
+}
+
 // Usage is an interface which can be implemented to show a custom usage string
 // in the help message shown for a command.
 type Usage interface {

--- a/command_test.go
+++ b/command_test.go
@@ -146,7 +146,7 @@ func TestCommandExecute(t *testing.T) {
 	}
 
 	if !opts.Command.G {
-		t.Errorf("Expected Command.C to be true")
+		t.Errorf("Expected Command.G to be true")
 	}
 
 	assertStringArray(t, opts.Command.EArgs, []string{"a", "b"})
@@ -333,5 +333,52 @@ func TestCommandAlias(t *testing.T) {
 
 	if !opts.Command.G {
 		t.Errorf("Expected G to be true")
+	}
+}
+
+type testCommandNoArgs struct {
+	G        bool `short:"g"`
+	Executed bool
+}
+
+func (c *testCommandNoArgs) Execute() error {
+	c.Executed = true
+
+	return nil
+}
+
+func TestCommandExecuteNoArgsOK(t *testing.T) {
+	var opts = struct {
+		Value bool `short:"v"`
+
+		Command testCommandNoArgs `command:"cmd"`
+	}{}
+
+	assertParseSuccess(t, &opts, "-v", "cmd", "-g")
+
+	if !opts.Value {
+		t.Errorf("Expected Value to be true")
+	}
+
+	if !opts.Command.Executed {
+		t.Errorf("Did not execute command")
+	}
+
+	if !opts.Command.G {
+		t.Errorf("Expected Command.G to be true")
+	}
+}
+
+func TestCommandExecuteNoArgsTooMany(t *testing.T) {
+	var opts = struct {
+		Value bool `short:"v"`
+
+		Command testCommandNoArgs `command:"cmd"`
+	}{}
+
+	assertParseFail(t, ErrTooManyArgs, "too many arguments: a, b, c", &opts,
+		"-v", "cmd", "-g", "a", "b", "c")
+	if opts.Command.Executed {
+		t.Errorf("Did not expect command to be executed")
 	}
 }

--- a/error.go
+++ b/error.go
@@ -52,6 +52,10 @@ const (
 
 	// ErrUnknownCommand indicates that an unknown command was specified.
 	ErrUnknownCommand
+
+	// ErrTooManyArgs indicates that unwanted, extra positional args
+	// were given.
+	ErrTooManyArgs
 )
 
 func (e ErrorType) String() string {

--- a/flags.go
+++ b/flags.go
@@ -160,7 +160,7 @@ There are currently two ways to specify a command.
 
     1. Use AddCommand on an existing parser.
     2. Add a struct field to your options struct annotated with the
-       command:"command-name" tag.
+       command:"command" tag.
 
 The most common, idiomatic way to implement commands is to define a global
 parser instance and implement each command in a separate file. These

--- a/parser.go
+++ b/parser.go
@@ -7,6 +7,7 @@ package flags
 import (
 	"os"
 	"path"
+	"strings"
 )
 
 // A Parser provides command line option parsing. It can contain several
@@ -229,6 +230,14 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 		reterr = p.printError(s.estimateCommand())
 	} else if cmd, ok := s.command.data.(Commander); ok {
 		reterr = p.printError(cmd.Execute(s.retargs))
+	} else if cmd, ok := s.command.data.(CommanderNoArgs); ok {
+		if len(s.retargs) > 0 {
+			reterr = p.printError(newErrorf(ErrTooManyArgs,
+				"too many arguments: %s",
+				strings.Join(s.retargs, ", ")))
+		} else {
+			reterr = p.printError(cmd.Execute())
+		}
 	}
 
 	if reterr != nil {


### PR DESCRIPTION
Allows more convenient validation against unwanted extra args.

Before:

        func (c *myStruct) Execute(args []string) error {
            if len(args) > 0 {
                return errors.New("got unwanted extra args")
            }
        }

After:

        func (c *myStruct) Execute() error {
            // extra args are checked automatically before calling Execute()
        }