### PR TITLE
Optional default values from environment variables

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -17,6 +17,7 @@ The following features are supported in go-flags:
     Options with long names (--verbose)
     Options with and without arguments (bool v.s. other type)
     Options with optional arguments and default values
+    Option default values from ENVIRONMENT_VARIABLES, including slice and map values
     Multiple option groups each containing a set of options
     Generate and print well-formatted help message
     Passing remaining command line arguments after -- (optional)
@@ -95,6 +96,12 @@ The following is a list of tags for struct fields supported by go-flags:
                     showing up in the help. If default-mask takes the special
                     value "-", then no default value will be shown at all
                     (optional)
+    env:            the default value of the option is overridden from the
+                    specified environment variable, if one has been defined.
+                    (optional)
+    env-delim:      the 'env' default value from environment is split into
+                    multiple values with the given delimiter string, use with
+                    slices and maps (optional)
     value-name:     the name of the argument value (to be shown in the help,
                     (optional)
 

--- a/group_private.go
+++ b/group_private.go
@@ -124,6 +124,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 
 		description := mtag.Get("description")
 		def := mtag.GetMany("default")
+
 		optionalValue := mtag.GetMany("optional-value")
 		valueName := mtag.Get("value-name")
 		defaultMask := mtag.Get("default-mask")
@@ -136,6 +137,8 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			ShortName:        short,
 			LongName:         longname,
 			Default:          def,
+			EnvDefaultKey:    mtag.Get("env"),
+			EnvDefaultDelim:  mtag.Get("env-delim"),
 			OptionalArgument: optional,
 			OptionalValue:    optionalValue,
 			Required:         required,

--- a/help.go
+++ b/help.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"runtime"
 	"strings"
 	"unicode/utf8"
 )
@@ -173,12 +174,24 @@ func (p *Parser) writeHelpOption(writer *bufio.Writer, option *Option, info alig
 			def = strings.Join(defs, ", ")
 		}
 
+		var envDef string
+		if option.EnvDefaultKey != "" {
+			var envPrintable string
+			if runtime.GOOS == "windows" {
+				envPrintable = "%" + option.EnvDefaultKey + "%"
+			} else {
+				envPrintable = "$" + option.EnvDefaultKey
+			}
+			envDef = fmt.Sprintf(" [%s]", envPrintable)
+		}
+
 		var desc string
 
 		if def != "" {
-			desc = fmt.Sprintf("%s (%v)", option.Description, def)
+			desc = fmt.Sprintf("%s (%v)%s", option.Description, def,
+				envDef)
 		} else {
-			desc = option.Description
+			desc = option.Description + envDef
 		}
 
 		writer.WriteString(wrapText(desc,

--- a/help_test.go
+++ b/help_test.go
@@ -54,6 +54,8 @@ type helpOptions struct {
 	Default      string            `long:"default" default:"Some value" description:"Test default value"`
 	DefaultArray []string          `long:"default-array" default:"Some value" default:"Another value" description:"Test default array value"`
 	DefaultMap   map[string]string `long:"default-map" default:"some:value" default:"another:value" description:"Testdefault map value"`
+	EnvDefault1  string            `long:"env-default1" default:"Some value" env:"ENV_DEFAULT" description:"Test env-default1 value"`
+	EnvDefault2  string            `long:"env-default2" env:"ENV_DEFAULT" description:"Test env-default2 value"`
 
 	OnlyIni string `ini-name:"only-ini" description:"Option only available in ini"`
 
@@ -81,8 +83,11 @@ type helpOptions struct {
 }
 
 func TestHelp(t *testing.T) {
-	var opts helpOptions
+	oldEnv := EnvSnapshot()
+	defer oldEnv.Restore()
+	os.Setenv("ENV_DEFAULT", "env-def")
 
+	var opts helpOptions
 	p := NewNamedParser("TestHelp", HelpFlag)
 	p.AddGroup("Application Options", "The application options", &opts)
 
@@ -113,6 +118,8 @@ Application Options:
       /default:            Test default value (Some value)
       /default-array:      Test default array value (Some value, Another value)
       /default-map:        Testdefault map value (some:value, another:value)
+      /env-default1:       Test env-default1 value (Some value) [%ENV_DEFAULT%]
+      /env-default2:       Test env-default2 value [%ENV_DEFAULT%]
 
 Other Options:
   /s:                      A slice of strings (some, value)
@@ -147,6 +154,8 @@ Application Options:
       --default=           Test default value (Some value)
       --default-array=     Test default array value (Some value, Another value)
       --default-map=       Testdefault map value (some:value, another:value)
+      --env-default1=      Test env-default1 value (Some value) [$ENV_DEFAULT]
+      --env-default2=      Test env-default2 value [$ENV_DEFAULT]
 
 Other Options:
   -s=                      A slice of strings (some, value)
@@ -184,8 +193,11 @@ Available commands:
 }
 
 func TestMan(t *testing.T) {
-	var opts helpOptions
+	oldEnv := EnvSnapshot()
+	defer oldEnv.Restore()
+	os.Setenv("ENV_DEFAULT", "env-def")
 
+	var opts helpOptions
 	p := NewNamedParser("TestMan", HelpFlag)
 	p.ShortDescription = "Test manpage generation"
 	p.LongDescription = "This is a somewhat `longer' description of what this does"
@@ -228,6 +240,12 @@ Test default array value
 .TP
 \fB--default-map\fP
 Testdefault map value
+.TP
+\fB--env-default1\fP
+Test env-default1 value
+.TP
+\fB--env-default2\fP
+Test env-default2 value
 .TP
 \fB-s\fP
 A slice of strings
@@ -273,8 +291,11 @@ type helpCommandNoOptions struct {
 }
 
 func TestHelpCommand(t *testing.T) {
-	var opts helpCommandNoOptions
+	oldEnv := EnvSnapshot()
+	defer oldEnv.Restore()
+	os.Setenv("ENV_DEFAULT", "env-def")
 
+	var opts helpCommandNoOptions
 	p := NewNamedParser("TestHelpCommand", HelpFlag)
 	p.AddGroup("Application Options", "The application options", &opts)
 

--- a/ini_test.go
+++ b/ini_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestWriteIni(t *testing.T) {
+	oldEnv := EnvSnapshot()
+	defer oldEnv.Restore()
+	os.Setenv("ENV_DEFAULT", "env-def")
+
 	var tests = []struct {
 		args     []string
 		options  IniOptions
@@ -21,6 +25,12 @@ func TestWriteIni(t *testing.T) {
 ; Show verbose debug information
 verbose = true
 verbose = true
+
+; Test env-default1 value
+EnvDefault1 = env-def
+
+; Test env-default2 value
+EnvDefault2 = env-def
 
 [Other Options]
 ; A map from string to int
@@ -52,6 +62,12 @@ DefaultArray = Another value
 ; Testdefault map value
 DefaultMap = another:value
 DefaultMap = some:value
+
+; Test env-default1 value
+EnvDefault1 = env-def
+
+; Test env-default2 value
+EnvDefault2 = env-def
 
 ; Option only available in ini
 only-ini =
@@ -102,6 +118,12 @@ Opt =
 ; DefaultMap = another:value
 ; DefaultMap = some:value
 
+; Test env-default1 value
+EnvDefault1 = env-def
+
+; Test env-default2 value
+EnvDefault2 = env-def
+
 ; Option only available in ini
 ; only-ini =
 
@@ -147,6 +169,12 @@ DefaultArray = New value
 
 ; Testdefault map value
 DefaultMap = new:value
+
+; Test env-default1 value
+EnvDefault1 = env-def
+
+; Test env-default2 value
+EnvDefault2 = env-def
 
 ; Option only available in ini
 ; only-ini =

--- a/option.go
+++ b/option.go
@@ -27,6 +27,12 @@ type Option struct {
 	// The default value of the option.
 	Default []string
 
+	// The optional environment default value key name.
+	EnvDefaultKey string
+
+	// The optional delimiter string for EnvDefaultKey values.
+	EnvDefaultDelim string
+
 	// If true, specifies that the argument to an option flag is optional.
 	// When no argument to the flag is specified on the command line, the
 	// value of Default will be set in the field this option represents.


### PR DESCRIPTION
Tags `env:"VARIABLE_NAME"` and `env-delim:"DELIM_STRING"` can
be optionally specified to get the option default value from
the corresponding environment variable.

The delimiter, if one is defined, is used to split the value
to multiple strings, making it possible to define default values
for both slices and maps thru the environment.

---

Addresses https://github.com/jessevdk/go-flags/issues/85

_Not_ tested under Windows.
