### PR TITLE
Allow multiline structure tags (ignore all the types of whitespace).

### DIFF
--- a/multitag.go
+++ b/multitag.go
@@ -15,6 +15,14 @@ func newMultiTag(v string) multiTag {
 	}
 }
 
+func isWhitespace(r uint8) bool {
+	switch rune(r) {
+	case ' ', '\n', '\r', '\t', '\v', '\f', 0x85, 0xA0:
+		return true
+	}
+	return false
+}
+
 func (x *multiTag) scan() (map[string][]string, error) {
 	v := x.value
 
@@ -25,7 +33,7 @@ func (x *multiTag) scan() (map[string][]string, error) {
 		i := 0
 
 		// Skip whitespace
-		for i < len(v) && v[i] == ' ' {
+		for i < len(v) && isWhitespace(v[i]) {
 			i++
 		}
 
@@ -38,7 +46,7 @@ func (x *multiTag) scan() (map[string][]string, error) {
 		// Scan to colon to find key
 		i = 0
 
-		for i < len(v) && v[i] != ' ' && v[i] != ':' && v[i] != '"' {
+		for i < len(v) && !isWhitespace(v[i]) && v[i] != ':' && v[i] != '"' {
 			i++
 		}
 


### PR DESCRIPTION
Hello. I'm quite surprised that there is no such feature has been discussed yet. I prefer to break struct tags into lines, but the multiTag scanner allows only `' '` as a whitespace.

The commit makes things like this possible:

``` go
type Options struct {
    Port int `short:"p" long:"port" default:"5051"
    description:"Specify a port to bind the web interface"`
}
```

(you know, the long-description may get even longer)
