### PR TITLE
YAML is pretty strict about indentations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 after_success:
-	- coveralls
+  - coveralls


### PR DESCRIPTION
Tabs are not allowed. Two spaces are commonly used.
