### PR TITLE
add complete coverage and send it to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,25 @@
 language: go
-after_success:
-  - coveralls
+
+install:
+  # go-flags
+  - go get -d -v ./...
+  - go build -v ./...
+
+  # code coverage
+  - go get code.google.com/p/go.tools/cmd/cover
+  - go get github.com/onsi/ginkgo/ginkgo
+  - go get github.com/modocache/gover
+  - go get github.com/mattn/goveralls
+
+script:
+  # go-flags
+  - go test -v ./...
+
+  # Code coverage
+  - $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/ginkgo -r -race -cover
+  - $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/gover
+  - $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN
+
+env:
+  # coveralls.io
+  secure: "secure COVERALLS_TOKEN env in here"


### PR DESCRIPTION
Can you please add the encrypted COVERALLS_TOKEN http://docs.travis-ci.com/user/encryption-keys/ or post it here so that I can include it in the commit

I know that the coverage via ginkgo/gover/goveralls looks way overdone but it is the only way I know to get coverage in one pass of all packages. So this should be safe for future additions.

I see that you currently upload the coverage via drone.io? So you like to switch from TravisCI?
