### PR TITLE
Improve travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - go test -v ./...
 
   # linting
-  - $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/go tool vet -all=true -v=true .
+  - go tool vet -all=true -v=true .
   - $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/golint .
 
   # code coverage


### PR DESCRIPTION
The linters are currently not failing the build if they find anything because I have currently no idea how to mark errors as false-positives. I will do that in the future but it is still good to have it in the build if the tools suddenly allow this.
