### PR TITLE
fix, empty string arguments lead to an index out of range panic

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -313,7 +313,7 @@ func quoteIfNeeded(s string) string {
 }
 
 func unquoteIfPossible(s string) (string, error) {
-	if s[0] != '"' {
+	if len(s) == 0 || s[0] != '"' {
 		return s, nil
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -75,7 +75,7 @@ func TestDefaults(t *testing.T) {
 		},
 		{
 			msg:  "zero value arguments, expecting overwritten arguments",
-			args: []string{"--i=0", "--id=0", "--str=\"\"", "--strd=\"\"", "--t=0ms", "--td=0s", "--m=:0", "--md=:0", "--s=0", "--sd=0"},
+			args: []string{"--i=0", "--id=0", "--str", "", "--strd=\"\"", "--t=0ms", "--td=0s", "--m=:0", "--md=:0", "--s=0", "--sd=0"},
 			expected: defaultOptions{
 				Int:        0,
 				IntDefault: 0,


### PR DESCRIPTION
An empty string argument leads to a panic. Kind of funny that this was not tested.
