### PR TITLE
Accept any single character arguments including ``-``

### DIFF
--- a/parser_private.go
+++ b/parser_private.go
@@ -170,6 +170,8 @@ func (p *Parser) parseOption(s *parseState, name string, option *Option, canarg 
 			arg = *argument
 		} else {
 			arg = s.pop()
+			// Accept any single character arguments including '-'.
+			// '-' is the special file name for the standard input or the standard output in many cases.
 			if len(arg) > 1 && argumentIsOption(arg) {
 				return newErrorf(ErrExpectedArgument, "expected argument for flag `%s', but got option `%s'", option, arg)
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -334,13 +334,12 @@ func TestOptionAsArgument(t *testing.T) {
 			errType:     ErrExpectedArgument,
 			errMsg:      "expected argument for flag `--string-slice', but got option `--'",
 		},
-
 		{
 			// quoted and appended option should be accepted as argument (even if it looks like an option)
 			args: []string{"--string-slice", "foobar", "--string-slice=\"--other-option\""},
 		},
 		{
-			//Accept any single character arguments including '-'
+			// Accept any single character arguments including '-'
 			args: []string{"--string-slice", "-"},
 		},
 	}


### PR DESCRIPTION
Many programs such as `sort` and `cat` treat the single character argument `-` as the special file name for the standard input or the standard output.
It is better to accept `-` in order to specify them by simply using  `-` as the argument, though it starts with `-`.
