### PR TITLE
unknown option handler should be able to handle flags in --flag=value format

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -26,28 +26,28 @@ type Parser struct {
 
 	// UnknownOptionsHandler is a function which gets called when the parser
 	// encounters an unknown option. The function receives the unknown option
-	// name, an Argument which specifies its value if set with '=', and the
-	// remaining command line arguments.
+	// name, a SplitArgument which specifies its value if set with an argument
+	// separator, and the remaining command line arguments.
 	// It should return a new list of remaining arguments to continue parsing,
 	// or an error to indicate a parse failure.
-	UnknownOptionHandler func(option string, arg Argument, args []string) ([]string, error)
+	UnknownOptionHandler func(option string, arg SplitArgument, args []string) ([]string, error)
 
 	internalError error
 }
 
-// Argument represents the value of an option that was passed on the command
-// line in the form "--flagName=value".
-type Argument interface {
+// SplitArgument represents the argument value of an option that was passed using
+// an argument separator.
+type SplitArgument interface {
 	// String returns the option's value as a string, and a boolean indicating
 	// if the option was present.
-	String() (string, bool)
+	Value() (string, bool)
 }
 
 type strArgument struct {
 	value *string
 }
 
-func (s strArgument) String() (string, bool) {
+func (s strArgument) Value() (string, bool) {
 	if s.value == nil {
 		return "", false
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -372,9 +372,9 @@ func TestUnknownFlagHandler(t *testing.T) {
 	var unknownFlag3 string
 
 	// Set up a callback to intercept unknown options during parsing
-	p.UnknownOptionHandler = func(option string, arg Argument, args []string) ([]string, error) {
+	p.UnknownOptionHandler = func(option string, arg SplitArgument, args []string) ([]string, error) {
 		if option == "unknownFlag1" {
-			if argValue, ok := arg.String(); ok {
+			if argValue, ok := arg.Value(); ok {
 				unknownFlag1 = argValue
 				return args, nil
 			}
@@ -386,7 +386,7 @@ func TestUnknownFlagHandler(t *testing.T) {
 			unknownFlag2 = true
 			return args, nil
 		} else if option == "unknownFlag3" {
-			if argValue, ok := arg.String(); ok {
+			if argValue, ok := arg.Value(); ok {
 				unknownFlag3 = argValue
 				return args, nil
 			}


### PR DESCRIPTION
I realized there is an edge case in my previous pull request that wasn't covered, which is that if the flag is specified as a single string with "=" then the value itself doesn't appear in the parser state's args array. This should fix it by passing the parsed value from splitOption into the unknown option handler function.
