### PR TITLE
add support for requiring `rest` positional args

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -12,8 +12,9 @@ type Arg struct {
 	// A description of the positional argument (used in the help)
 	Description string
 
-	value reflect.Value
-	tag   multiTag
+	value    reflect.Value
+	tag      multiTag
+	required bool
 }
 
 func (a *Arg) isRemaining() bool {

--- a/arg_test.go
+++ b/arg_test.go
@@ -51,3 +51,20 @@ func TestPositionalRequired(t *testing.T) {
 
 	assertError(t, err, ErrRequired, "the required argument `Filename` was not provided")
 }
+
+func TestPositionalRestRequired(t *testing.T) {
+	var opts = struct {
+		Value bool `short:"v"`
+
+		Positional struct {
+			Command  int
+			Filename string
+			Rest     []string `required:"yes"`
+		} `positional-args:"yes" required:"yes"`
+	}{}
+
+	p := NewParser(&opts, None)
+	_, err := p.ParseArgs([]string{"10", "arg_test.go"})
+
+	assertError(t, err, ErrRequired, "the required argument `Rest` was not provided")
+}

--- a/command_private.go
+++ b/command_private.go
@@ -53,8 +53,9 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 					Name:        name,
 					Description: m.Get("description"),
 
-					value: realval.Field(i),
-					tag:   m,
+					value:    realval.Field(i),
+					tag:      m,
+					required: len(m.Get("required")) != 0,
 				}
 
 				c.args = append(c.args, arg)

--- a/parser_private.go
+++ b/parser_private.go
@@ -65,7 +65,7 @@ func (p *parseState) checkRequired(parser *Parser) error {
 			var reqnames []string
 
 			for _, arg := range p.positional {
-				if arg.isRemaining() {
+				if arg.isRemaining() && !arg.required {
 					break
 				}
 


### PR DESCRIPTION
By default the slice in the end of positional args is not required, but often that
sort of slice is used for example in cases where multiple file names are passed
and at least one is required. To support this use case, add support for specifying
`required` tag for the last slice of positional args and check that when verifying
command arguments.
