### PR TITLE
Add docs on naming positional args

### DIFF
--- a/command_private.go
+++ b/command_private.go
@@ -43,7 +43,7 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 					return true, err
 				}
 
-				name := m.Get("name")
+				name := m.Get("positional-arg-name")
 
 				if len(name) == 0 {
 					name = field.Name

--- a/flags.go
+++ b/flags.go
@@ -102,7 +102,7 @@ The following is a list of tags for struct fields supported by go-flags:
     env-delim:      the 'env' default value from environment is split into
                     multiple values with the given delimiter string, use with
                     slices and maps (optional)
-    value-name:     the name of the argument value (to be shown in the help,
+    value-name:     the name of the argument value (to be shown in the help)
                     (optional)
 
     base: a base (radix) used to convert strings to integer values, the

--- a/flags.go
+++ b/flags.go
@@ -134,6 +134,10 @@ The following is a list of tags for struct fields supported by go-flags:
                           Positional arguments are optional by default,
                           unless the "required" tag is specified together
                           with the "positional-args" tag (optional)
+    positional-arg-name:  used on a field in a positional argument struct; name
+                          of the positional argument placeholder to be shown in
+                          the help (optional)
+
 
 Either the `short:` tag or the `long:` must be specified to make the field eligible as an
 option.

--- a/help_test.go
+++ b/help_test.go
@@ -15,11 +15,12 @@ type helpOptions struct {
 	PtrSlice         []*string    `long:"ptrslice" description:"A slice of pointers to string"`
 	EmptyDescription bool         `long:"empty-description"`
 
-	Default      string            `long:"default" default:"Some\nvalue" description:"Test default value"`
-	DefaultArray []string          `long:"default-array" default:"Some value" default:"Other\tvalue" description:"Test default array value"`
-	DefaultMap   map[string]string `long:"default-map" default:"some:value" default:"another:value" description:"Testdefault map value"`
-	EnvDefault1  string            `long:"env-default1" default:"Some value" env:"ENV_DEFAULT" description:"Test env-default1 value"`
-	EnvDefault2  string            `long:"env-default2" env:"ENV_DEFAULT" description:"Test env-default2 value"`
+	Default           string            `long:"default" default:"Some\nvalue" description:"Test default value"`
+	DefaultArray      []string          `long:"default-array" default:"Some value" default:"Other\tvalue" description:"Test default array value"`
+	DefaultMap        map[string]string `long:"default-map" default:"some:value" default:"another:value" description:"Testdefault map value"`
+	EnvDefault1       string            `long:"env-default1" default:"Some value" env:"ENV_DEFAULT" description:"Test env-default1 value"`
+	EnvDefault2       string            `long:"env-default2" env:"ENV_DEFAULT" description:"Test env-default2 value"`
+	OptionWithArgName string            `long:"opt-with-arg-name" value-name:"something" description:"Option with named argument"`
 
 	OnlyIni string `ini-name:"only-ini" description:"Option only available in ini"`
 
@@ -75,33 +76,34 @@ func TestHelp(t *testing.T) {
   TestHelp [OPTIONS] [filename] [num] <command>
 
 Application Options:
-  /v, /verbose             Show verbose debug information
-  /c:                      Call phone number
-      /ptrslice:           A slice of pointers to string
+  /v, /verbose                         Show verbose debug information
+  /c:                                  Call phone number
+      /ptrslice:                       A slice of pointers to string
       /empty-description
-      /default:            Test default value ("Some\nvalue")
-      /default-array:      Test default array value (Some value, "Other\tvalue")
-      /default-map:        Testdefault map value (some:value, another:value)
-      /env-default1:       Test env-default1 value (Some value) [%ENV_DEFAULT%]
-      /env-default2:       Test env-default2 value [%ENV_DEFAULT%]
+      /default:                        Test default value ("Some\nvalue")
+      /default-array:                  Test default array value (Some value, "Other\tvalue")
+      /default-map:                    Testdefault map value (some:value, another:value)
+      /env-default1:                   Test env-default1 value (Some value) [%ENV_DEFAULT%]
+      /env-default2:                   Test env-default2 value [%ENV_DEFAULT%]
+      /opt-with-arg-name:something     Option with named argument
 
 Other Options:
-  /s:                      A slice of strings (some, value)
-      /intmap:             A map from string to int (a:1)
+  /s:                                  A slice of strings (some, value)
+      /intmap:                         A map from string to int (a:1)
 
 Subgroup:
-      /sip.opt:            This is a subgroup option
+      /sip.opt:                        This is a subgroup option
 
 Subsubgroup:
-      /sip.sap.opt:        This is a subsubgroup option
+      /sip.sap.opt:                    This is a subsubgroup option
 
 Help Options:
-  /?                       Show this help message
-  /h, /help                Show this help message
+  /?                                   Show this help message
+  /h, /help                            Show this help message
 
 Arguments:
-  filename:                A filename
-  num:                     A number
+  filename:                            A filename
+  num:                                 A number
 
 Available commands:
   command  A command (aliases: cm, cmd)
@@ -111,32 +113,36 @@ Available commands:
   TestHelp [OPTIONS] [filename] [num] <command>
 
 Application Options:
-  -v, --verbose            Show verbose debug information
-  -c=                      Call phone number
-      --ptrslice=          A slice of pointers to string
+  -v, --verbose                        Show verbose debug information
+  -c=                                  Call phone number
+      --ptrslice=                      A slice of pointers to string
       --empty-description
-      --default=           Test default value ("Some\nvalue")
-      --default-array=     Test default array value (Some value, "Other\tvalue")
-      --default-map=       Testdefault map value (some:value, another:value)
-      --env-default1=      Test env-default1 value (Some value) [$ENV_DEFAULT]
-      --env-default2=      Test env-default2 value [$ENV_DEFAULT]
+      --default=                       Test default value ("Some\nvalue")
+      --default-array=                 Test default array value (Some value,
+                                       "Other\tvalue")
+      --default-map=                   Testdefault map value (some:value,
+                                       another:value)
+      --env-default1=                  Test env-default1 value (Some value)
+                                       [$ENV_DEFAULT]
+      --env-default2=                  Test env-default2 value [$ENV_DEFAULT]
+      --opt-with-arg-name=something    Option with named argument
 
 Other Options:
-  -s=                      A slice of strings (some, value)
-      --intmap=            A map from string to int (a:1)
+  -s=                                  A slice of strings (some, value)
+      --intmap=                        A map from string to int (a:1)
 
 Subgroup:
-      --sip.opt=           This is a subgroup option
+      --sip.opt=                       This is a subgroup option
 
 Subsubgroup:
-      --sip.sap.opt=       This is a subsubgroup option
+      --sip.sap.opt=                   This is a subsubgroup option
 
 Help Options:
-  -h, --help               Show this help message
+  -h, --help                           Show this help message
 
 Arguments:
-  filename:                A filename
-  num:                     A number
+  filename:                            A filename
+  num:                                 A number
 
 Available commands:
   command  A command (aliases: cm, cmd)
@@ -201,6 +207,9 @@ Test env-default1 value
 .TP
 \fB--env-default2\fP
 Test env-default2 value
+.TP
+\fB--opt-with-arg-name\fP
+Option with named argument
 .TP
 \fB-s\fP
 A slice of strings

--- a/help_test.go
+++ b/help_test.go
@@ -41,8 +41,8 @@ type helpOptions struct {
 	} `command:"command" alias:"cm" alias:"cmd" description:"A command"`
 
 	Args struct {
-		Filename string `name:"filename" description:"A filename"`
-		Num      int    `name:"num" description:"A number"`
+		Filename string `positional-arg-name:"filename" description:"A filename"`
+		Number   int    `positional-arg-name:"num" description:"A number"`
 	} `positional-args:"yes"`
 }
 

--- a/ini_test.go
+++ b/ini_test.go
@@ -71,6 +71,9 @@ EnvDefault1 = env-def
 ; Test env-default2 value
 EnvDefault2 = env-def
 
+; Option with named argument
+OptionWithArgName =
+
 ; Option only available in ini
 only-ini =
 
@@ -126,6 +129,9 @@ EnvDefault1 = env-def
 ; Test env-default2 value
 EnvDefault2 = env-def
 
+; Option with named argument
+; OptionWithArgName =
+
 ; Option only available in ini
 ; only-ini =
 
@@ -177,6 +183,9 @@ EnvDefault1 = env-def
 
 ; Test env-default2 value
 EnvDefault2 = env-def
+
+; Option with named argument
+; OptionWithArgName =
 
 ; Option only available in ini
 ; only-ini =


### PR DESCRIPTION
From the existing docs one would assume that you could use `value-name` to change how positional args are presented in the help, but it's actually `name`. I could also put together a patch to change the implementation so that they both use `value-name` if you like — not sure how much you want to preserve backwards compatibility here.