### PR TITLE
Support for long paragraphs

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -320,6 +320,20 @@ func unquoteIfPossible(s string) (string, error) {
 	return strconv.Unquote(s)
 }
 
+func wrapParagraph(s string, l int, prefix string) string {
+	paragraphs := strings.Split(s, "\n\n")
+
+	for i := range paragraphs {
+		paragraphs[i] = wrapText(paragraphs[i], l, prefix)
+
+		if i != 0 {
+			paragraphs[i] = prefix + paragraphs[i]
+		}
+	}
+
+	return strings.Join(paragraphs, "\n\n")
+}
+
 func wrapText(s string, l int, prefix string) string {
 	// Basic text wrapping of s at spaces to fit in l
 	var ret string

--- a/convert_test.go
+++ b/convert_test.go
@@ -173,3 +173,26 @@ func TestWrapText(t *testing.T) {
 
 	assertDiff(t, got, expected, "wrapped text")
 }
+
+func TestWrapParagraph(t *testing.T) {
+	s := "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\n"
+	s += "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\n"
+	s += "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\n\n"
+	s += "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+
+	got := wrapParagraph(s, 60, "      ")
+	expected := `Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+      sed do eiusmod tempor incididunt ut labore et dolore magna
+      aliqua.
+
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco
+      laboris nisi ut aliquip ex ea commodo consequat.
+
+      Duis aute irure dolor in reprehenderit in voluptate velit
+      esse cillum dolore eu fugiat nulla pariatur.
+
+      Excepteur sint occaecat cupidatat non proident, sunt in
+      culpa qui officia deserunt mollit anim id est laborum.`
+
+	assertDiff(t, got, expected, "wrapped paragraph")
+}

--- a/help.go
+++ b/help.go
@@ -324,7 +324,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 		if len(cmd.LongDescription) != 0 {
 			fmt.Fprintln(wr)
 
-			t := wrapText(cmd.LongDescription,
+			t := wrapParagraph(cmd.LongDescription,
 				aligninfo.terminalColumns,
 				"")
 


### PR DESCRIPTION
Adding support for splitting paragraphs from a long description provided
by a command.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>