### PR TITLE
Add "Hidden" option to comamnds and options

### DIFF
--- a/command.go
+++ b/command.go
@@ -23,6 +23,9 @@ type Command struct {
 	// Whether positional arguments are required
 	ArgsRequired bool
 
+	// If true, the option is not displayed in the help output
+	Hidden bool
+
 	commands            []*Command
 	hasBuiltinHelpGroup bool
 	args                []*Arg

--- a/command_private.go
+++ b/command_private.go
@@ -201,9 +201,15 @@ func (c commandList) Swap(i, j int) {
 	c[i], c[j] = c[j], c[i]
 }
 
+// FIXME: maybe call this sortedVisibleCommands ?
 func (c *Command) sortedCommands() []*Command {
-	ret := make(commandList, len(c.commands))
-	copy(ret, c.commands)
+	ret := make(commandList, 0, len(c.commands))
+
+	for _, e := range c.commands {
+		if !e.Hidden {
+			ret = append(ret, e)
+		}
+	}
 
 	sort.Sort(ret)
 	return []*Command(ret)

--- a/flags.go
+++ b/flags.go
@@ -104,6 +104,7 @@ The following is a list of tags for struct fields supported by go-flags:
                     slices and maps (optional)
     value-name:     the name of the argument value (to be shown in the help)
                     (optional)
+    hidden:         the option is not visible in the help output
 
     base: a base (radix) used to convert strings to integer values, the
           default base is 10 (i.e. decimal) (optional)

--- a/group_private.go
+++ b/group_private.go
@@ -131,6 +131,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 
 		optional := (mtag.Get("optional") != "")
 		required := (mtag.Get("required") != "")
+		hidden := (mtag.Get("hidden") != "")
 
 		option := &Option{
 			Description:      description,
@@ -144,6 +145,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			Required:         required,
 			ValueName:        valueName,
 			DefaultMask:      defaultMask,
+			Hidden:           hidden,
 
 			group: g,
 

--- a/help.go
+++ b/help.go
@@ -108,6 +108,10 @@ func (p *Parser) writeHelpOption(writer *bufio.Writer, option *Option, info alig
 		prefix += 4
 	}
 
+	if option.Hidden {
+		return
+	}
+
 	line.WriteString(strings.Repeat(" ", prefix))
 
 	if option.ShortName != 0 {

--- a/option.go
+++ b/option.go
@@ -51,6 +51,9 @@ type Option struct {
 	// error.
 	Required bool
 
+	// If true, the option is not displayed in the help output
+	Hidden bool
+
 	// A name for the value of an option shown in the Help as --flag [ValueName]
 	ValueName string
 


### PR DESCRIPTION
A small branch that adds a way to hide internal options from the help output. Tests are missing, I'm happy to write them if there is a chance for this branch to get merged :)