### PR TITLE
Output a blank .TP section after usage to fix rendering issue

### DIFF
--- a/man.go
+++ b/man.go
@@ -113,7 +113,7 @@ func writeManPageCommand(wr io.Writer, name string, root *Command, command *Comm
 	}
 
 	if len(usage) > 0 {
-		fmt.Fprintf(wr, "\n\\fBUsage\\fP: %s %s\n\n", pre, usage)
+		fmt.Fprintf(wr, "\n\\fBUsage\\fP: %s %s\n.TP\n", pre, usage)
 	}
 
 	if len(command.Aliases) > 0 {


### PR DESCRIPTION
Running `groff -mandoc -Thtml` on some generated troff output currently generates html like this (Usage line and flag run together):

```html
<p style="margin-left:11%; margin-top: 1em"><b>Usage</b>:
foobar [OPTIONS] start [start-OPTIONS] <b><br>
-l, --listen</b></p>
```
By adding this blank .TP after the Usage line it will render more appropriately like so:

```html
<p style="margin-left:11%; margin-top: 1em"><b>Usage</b>:
foobar [OPTIONS] start [start-OPTIONS]</p>

<p style="margin-left:11%; margin-top: 1em"><b>-l,
--listen</b></p>
```