### PR TITLE
Accept arguments which start with '-' if the next character is a digit

### DIFF
--- a/optstyle_other.go
+++ b/optstyle_other.go
@@ -4,7 +4,6 @@ package flags
 
 import (
 	"strings"
-	"unicode"
 )
 
 const (
@@ -18,7 +17,7 @@ func argumentStartsOption(arg string) bool {
 }
 
 func argumentIsOption(arg string) bool {
-	if len(arg) > 1 && arg[0] == '-' && arg[1] != '-' && !unicode.IsDigit(rune(arg[1])) {
+	if len(arg) > 1 && arg[0] == '-' && arg[1] != '-' {
 		return true
 	}
 

--- a/optstyle_other.go
+++ b/optstyle_other.go
@@ -4,6 +4,7 @@ package flags
 
 import (
 	"strings"
+	"unicode"
 )
 
 const (
@@ -17,7 +18,7 @@ func argumentStartsOption(arg string) bool {
 }
 
 func argumentIsOption(arg string) bool {
-	if len(arg) > 1 && arg[0] == '-' && arg[1] != '-' {
+	if len(arg) > 1 && arg[0] == '-' && arg[1] != '-' && !unicode.IsDigit(rune(arg[1])) {
 		return true
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -357,11 +357,11 @@ func TestOptionAsArgument(t *testing.T) {
 			args: []string{"--string-slice", "-"},
 		},
 		{
-			// Accept argumtns which start with '-' if the next character is a digit
+			// Accept arguments which start with '-' if the next character is a digit
 			args: []string{"--string-slice", "-3.14"},
 		},
 		{
-			// Do not accept argumtns which start with '-' if the next character is not a digit
+			// Do not accept arguments which start with '-' if the next character is not a digit
 			args:        []string{"--string-slice", "-character"},
 			expectError: true,
 			errType:     ErrExpectedArgument,

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,6 +14,9 @@ type defaultOptions struct {
 	Int        int `long:"i"`
 	IntDefault int `long:"id" default:"1"`
 
+	Float64        float64 `long:"f"`
+	Float64Default float64 `long:"fd" default:"-3.14"`
+
 	String            string `long:"str"`
 	StringDefault     string `long:"strd" default:"abc"`
 	StringNotUnquoted string `long:"strnot" unquote:"false"`
@@ -41,6 +44,9 @@ func TestDefaults(t *testing.T) {
 				Int:        0,
 				IntDefault: 1,
 
+				Float64:        0.0,
+				Float64Default: -3.14,
+
 				String:        "",
 				StringDefault: "abc",
 
@@ -56,10 +62,13 @@ func TestDefaults(t *testing.T) {
 		},
 		{
 			msg:  "non-zero value arguments, expecting overwritten arguments",
-			args: []string{"--i=3", "--id=3", "--str=def", "--strd=def", "--t=3ms", "--td=3ms", "--m=c:3", "--md=c:3", "--s=3", "--sd=3"},
+			args: []string{"--i=3", "--id=3", "--f=-2.71", "--fd=2.71", "--str=def", "--strd=def", "--t=3ms", "--td=3ms", "--m=c:3", "--md=c:3", "--s=3", "--sd=3"},
 			expected: defaultOptions{
 				Int:        3,
 				IntDefault: 3,
+
+				Float64:        -2.71,
+				Float64Default: 2.71,
 
 				String:        "def",
 				StringDefault: "def",
@@ -76,10 +85,13 @@ func TestDefaults(t *testing.T) {
 		},
 		{
 			msg:  "zero value arguments, expecting overwritten arguments",
-			args: []string{"--i=0", "--id=0", "--str", "", "--strd=\"\"", "--t=0ms", "--td=0s", "--m=:0", "--md=:0", "--s=0", "--sd=0"},
+			args: []string{"--i=0", "--id=0", "--f=0", "--fd=0", "--str", "", "--strd=\"\"", "--t=0ms", "--td=0s", "--m=:0", "--md=:0", "--s=0", "--sd=0"},
 			expected: defaultOptions{
 				Int:        0,
 				IntDefault: 0,
+
+				Float64:        0,
+				Float64Default: 0,
 
 				String:        "",
 				StringDefault: "",
@@ -343,6 +355,17 @@ func TestOptionAsArgument(t *testing.T) {
 		{
 			// Accept any single character arguments including '-'
 			args: []string{"--string-slice", "-"},
+		},
+		{
+			// Accept argumtns which start with '-' if the next character is a digit
+			args: []string{"--string-slice", "-3.14"},
+		},
+		{
+			// Do not accept argumtns which start with '-' if the next character is not a digit
+			args:        []string{"--string-slice", "-character"},
+			expectError: true,
+			errType:     ErrExpectedArgument,
+			errMsg:      "expected argument for flag `--string-slice', but got option `-character'",
 		},
 		{
 			args: []string{"-o", "-", "-"},

--- a/parser_test.go
+++ b/parser_test.go
@@ -17,6 +17,8 @@ type defaultOptions struct {
 	Float64        float64 `long:"f"`
 	Float64Default float64 `long:"fd" default:"-3.14"`
 
+	NumericFlag bool `short:"3" default:"false"`
+
 	String            string `long:"str"`
 	StringDefault     string `long:"strd" default:"abc"`
 	StringNotUnquoted string `long:"strnot" unquote:"false"`
@@ -47,6 +49,8 @@ func TestDefaults(t *testing.T) {
 				Float64:        0.0,
 				Float64Default: -3.14,
 
+				NumericFlag: false,
+
 				String:        "",
 				StringDefault: "abc",
 
@@ -62,13 +66,15 @@ func TestDefaults(t *testing.T) {
 		},
 		{
 			msg:  "non-zero value arguments, expecting overwritten arguments",
-			args: []string{"--i=3", "--id=3", "--f=-2.71", "--fd=2.71", "--str=def", "--strd=def", "--t=3ms", "--td=3ms", "--m=c:3", "--md=c:3", "--s=3", "--sd=3"},
+			args: []string{"--i=3", "--id=3", "--f=-2.71", "--fd=2.71", "-3", "--str=def", "--strd=def", "--t=3ms", "--td=3ms", "--m=c:3", "--md=c:3", "--s=3", "--sd=3"},
 			expected: defaultOptions{
 				Int:        3,
 				IntDefault: 3,
 
 				Float64:        -2.71,
 				Float64Default: 2.71,
+
+				NumericFlag: true,
 
 				String:        "def",
 				StringDefault: "def",
@@ -357,8 +363,11 @@ func TestOptionAsArgument(t *testing.T) {
 			args: []string{"--string-slice", "-"},
 		},
 		{
-			// Accept arguments which start with '-' if the next character is a digit
-			args: []string{"--string-slice", "-3.14"},
+			// Do not accept arguments which start with '-' even if the next character is a digit
+			args:        []string{"--string-slice", "-3.14"},
+			expectError: true,
+			errType:     ErrExpectedArgument,
+			errMsg:      "expected argument for flag `--string-slice', but got option `-3.14'",
 		},
 		{
 			// Do not accept arguments which start with '-' if the next character is not a digit


### PR DESCRIPTION
Currently, minus values like ``-3.14`` are not acceptable for the argument.
With this PR, arguments which start with '-' if the next character is a digit will be acceptable.