### PR TITLE
Fix for passing global flags after subcommands 

### DIFF
--- a/command_private.go
+++ b/command_private.go
@@ -149,6 +149,8 @@ func (c *Command) makeLookup() lookup {
 	for parent != nil {
 		if cmd, ok := parent.(*Command); ok {
 			cmd.fillLookup(&ret, true)
+			parent = cmd.parent
+			continue
 		}
 
 		if grp, ok := parent.(*Group); ok {

--- a/command_test.go
+++ b/command_test.go
@@ -400,3 +400,21 @@ func TestCommandAlias(t *testing.T) {
 		t.Errorf("Expected G to be true")
 	}
 }
+
+func TestGlobalFlagAfterSubcommand(t *testing.T) {
+	var opts = struct {
+		Flag    bool `long:"flag" default:"false"`
+		Command struct {
+			Subcommand struct {
+			} `command:"subcmd"`
+		} `command:"cmd"`
+	}{}
+
+	assertParseSuccess(t, &opts, "--flag", "cmd", "subcmd")
+	assertParseSuccess(t, &opts, "cmd", "--flag", "subcmd")
+	assertParseSuccess(t, &opts, "cmd", "subcmd", "--flag")
+
+	if !opts.Flag {
+		t.Errorf("Expected Flag to be true")
+	}
+}


### PR DESCRIPTION
e.g. `program command subcommand --flag`