### PR TITLE
check err before using subc

### DIFF
--- a/command.go
+++ b/command.go
@@ -223,12 +223,11 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 			aliases := mtag.GetMany("alias")
 
 			subc, err := c.AddCommand(subcommand, shortDescription, longDescription, ptrval.Interface())
-
-			subc.Hidden = mtag.Get("hidden") != ""
-
 			if err != nil {
 				return true, err
 			}
+
+			subc.Hidden = mtag.Get("hidden") != ""
 
 			if len(subcommandsOptional) > 0 {
 				subc.SubcommandsOptional = true


### PR DESCRIPTION
Fixes:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x49efc4]

goroutine 1 [running]:
github.com/jessevdk/go-flags.(*Command).scanSubcommandHandler.func1(0x777f80, 0xc8200b71e0, 0xd9, 0xc8200fb0a0, 0x777f80, 0x0, 0x0)
	...src/github.com/jessevdk/go-flags/command.go:229 +0xb24
github.com/jessevdk/go-flags.(*Group).scanStruct(0xc8200a0360, 0x777f80, 0xc8200b71e0, 0xd9, 0xc8200fb0a0, 0xc82006efa0, 0x0, 0x0)
	...src/github.com/jessevdk/go-flags/group.go:179 +0xde
github.com/jessevdk/go-flags.(*Group).scanStruct(0xc8200a0360, 0x7b3b00, 0xc8200b7000, 0xd9, 0x0, 0xc82006efa0, 0x0, 0x0)
	...src/github.com/jessevdk/go-flags/group.go:210 +0x402
github.com/jessevdk/go-flags.(*Group).scanType(0xc8200a0360, 0xc82006efa0, 0x0, 0x0)
	...src/github.com/jessevdk/go-flags/group.go:356 +0x22f
github.com/jessevdk/go-flags.(*Command).AddGroup(0xc820086580, 0x7f35e0, 0x13, 0x0, 0x0, 0x6a7c40, 0xc8200b7000, 0x40ee76, 0x0, 0x0)
	...src/github.com/jessevdk/go-flags/command.go:91 +0x193
github.com/jessevdk/go-flags.NewParser(0x6a7c40, 0xc8200b7000, 0x6, 0x7f3680)
	...src/github.com/jessevdk/go-flags/parser.go:145 +0x324
main.main()
	...main.go:47 +0x54

goroutine 18 [syscall]:
os/signal.loop()
	/usr/local/Cellar/go/1.5.1/libexec/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
	/usr/local/Cellar/go/1.5.1/libexec/src/os/signal/signal_unix.go:28 +0x37
```