### PR TITLE
Parse unexported embedded option struct fields in Go 1.6 (consistent w/pre-Go 1.6)

### DIFF
--- a/group.go
+++ b/group.go
@@ -187,7 +187,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		field := stype.Field(i)
 
 		// PkgName is set only for non-exported fields, which we ignore
-		if field.PkgPath != "" {
+		if field.PkgPath != "" && !field.Anonymous {
 			continue
 		}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -471,3 +471,17 @@ func TestChoices(t *testing.T) {
 	assertParseSuccess(t, &opts, "--choose", "v2")
 	assertString(t, opts.Choice, "v2")
 }
+
+func TestEmbedded(t *testing.T) {
+	type embedded struct {
+		V bool `short:"v"`
+	}
+	var opts struct {
+		embedded
+	}
+
+	assertParseSuccess(t, &opts, "-v")
+	if !opts.V {
+		t.Errorf("Expected V to be true")
+	}
+}


### PR DESCRIPTION
Pre-Go 1.6, the newly added TestEmbeddedUnexported test passes. In Go 1.6beta1, it fails:

```
$ go test
--- FAIL: TestEmbedded (0.00s)
        assert_test.go:92: Unexpected parse error: unknown flag `v'
```

This commit makes the behavior consistent across Go versions.

Related: https://github.com/golang/go/issues/12367, specifically the comments about how "code that assumes `f.PkgPath != nil` means a field is unexported and must be ignored must now be revised to check for `f.PkgPath != nil && !f.Anonymous` for it to walk into the embedded structs to look for exported fields contained within."