### PR TITLE
ini: allow specifying group opts directly on subcommands

### DIFF
--- a/group.go
+++ b/group.go
@@ -139,27 +139,29 @@ func (g *Group) optionByName(name string, namematch func(*Option, string) bool) 
 	prio := 0
 	var retopt *Option
 
-	for _, opt := range g.options {
-		if namematch != nil && namematch(opt, name) && prio < 4 {
-			retopt = opt
-			prio = 4
-		}
+	g.eachGroup(func(g *Group) {
+		for _, opt := range g.options {
+			if namematch != nil && namematch(opt, name) && prio < 4 {
+				retopt = opt
+				prio = 4
+			}
 
-		if name == opt.field.Name && prio < 3 {
-			retopt = opt
-			prio = 3
-		}
+			if name == opt.field.Name && prio < 3 {
+				retopt = opt
+				prio = 3
+			}
 
-		if name == opt.LongNameWithNamespace() && prio < 2 {
-			retopt = opt
-			prio = 2
-		}
+			if name == opt.LongNameWithNamespace() && prio < 2 {
+				retopt = opt
+				prio = 2
+			}
 
-		if opt.ShortName != 0 && name == string(opt.ShortName) && prio < 1 {
-			retopt = opt
-			prio = 1
+			if opt.ShortName != 0 && name == string(opt.ShortName) && prio < 1 {
+				retopt = opt
+				prio = 1
+			}
 		}
-	}
+	})
 
 	return retopt
 }

--- a/ini_test.go
+++ b/ini_test.go
@@ -248,6 +248,92 @@ EnvDefault2 = env-def
 	}
 }
 
+func TestReadIni_flagEquivalent(t *testing.T) {
+	type options struct {
+		Opt1 bool `long:"opt1"`
+
+		Group1 struct {
+			Opt2 bool `long:"opt2"`
+		} `group:"group1"`
+
+		Group2 struct {
+			Opt3 bool `long:"opt3"`
+		} `group:"group2" namespace:"ns1"`
+
+		Cmd1 struct {
+			Opt4 bool `long:"opt4"`
+			Opt5 bool `long:"foo.opt5"`
+
+			Group1 struct {
+				Opt6 bool `long:"opt6"`
+				Opt7 bool `long:"foo.opt7"`
+			} `group:"group1"`
+
+			Group2 struct {
+				Opt8 bool `long:"opt8"`
+			} `group:"group2" namespace:"ns1"`
+		} `command:"cmd1"`
+	}
+
+	a := `
+opt1=true
+
+[group1]
+opt2=true
+
+[group2]
+ns1.opt3=true
+
+[cmd1]
+opt4=true
+foo.opt5=true
+
+[cmd1.group1]
+opt6=true
+foo.opt7=true
+
+[cmd1.group2]
+ns1.opt8=true
+`
+	b := `
+opt1=true
+opt2=true
+ns1.opt3=true
+
+[cmd1]
+opt4=true
+foo.opt5=true
+opt6=true
+foo.opt7=true
+ns1.opt8=true
+`
+
+	parse := func(readIni string) (opts options, writeIni string) {
+		p := NewNamedParser("TestIni", Default)
+		p.AddGroup("Application Options", "The application options", &opts)
+
+		inip := NewIniParser(p)
+		err := inip.Parse(strings.NewReader(readIni))
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %s\n\nFile:\n%s", err, readIni)
+		}
+
+		var b bytes.Buffer
+		inip.Write(&b, Default)
+
+		return opts, b.String()
+	}
+
+	aOpt, aIni := parse(a)
+	bOpt, bIni := parse(b)
+
+	assertDiff(t, aIni, bIni, "")
+	if !reflect.DeepEqual(aOpt, bOpt) {
+		t.Errorf("not equal")
+	}
+}
+
 func TestReadIni(t *testing.T) {
 	var opts helpOptions
 


### PR DESCRIPTION
Simplifies the mental mapping of CLI flag name to INI config property
name.

See https://github.com/jessevdk/go-flags/issues/157 for more
information.