### PR TITLE
Add support for skipping arguments in help output

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -15,6 +15,10 @@ type Arg struct {
 	// Whether a positional argument is required
 	Required int
 
+	// If true, the argument is not displayed in the help or man page
+	// but is still displayed by the usage line.
+	SkipHelp bool
+
 	value reflect.Value
 	tag   multiTag
 }

--- a/command.go
+++ b/command.go
@@ -197,6 +197,7 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 					Name:        name,
 					Description: m.Get("description"),
 					Required:    required,
+					SkipHelp:    m.Get("skip-help") != "",
 
 					value: realval.Field(i),
 					tag:   m,

--- a/help.go
+++ b/help.go
@@ -412,7 +412,14 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			}
 		})
 
-		if len(c.args) > 0 {
+		var args []*Arg
+		for _, arg := range c.args {
+			if !arg.SkipHelp {
+				args = append(args, arg)
+			}
+		}
+
+		if len(args) > 0 {
 			if c == p.Command {
 				fmt.Fprintf(wr, "\nArguments:\n")
 			} else {
@@ -421,7 +428,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 
 			maxlen := aligninfo.descriptionStart()
 
-			for _, arg := range c.args {
+			for _, arg := range args {
 				prefix := strings.Repeat(" ", paddingBeforeOption)
 				fmt.Fprintf(wr, "%s%s", prefix, arg.Name)
 


### PR DESCRIPTION
This patch adds support for "skip-help" tag that can be added to
positional arguments. Presence of this tag hides an argument from help
output. This is useful for arguments that have obvious meaning and the
repetition does not make the help output more useful.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>