### PR TITLE
Don't display description-less positional args in --help

### DIFF
--- a/help.go
+++ b/help.go
@@ -412,7 +412,14 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			}
 		})
 
-		if len(c.args) > 0 {
+		var args []*Arg
+		for _, arg := range c.args {
+			if arg.Description != "" {
+				args = append(args, arg)
+			}
+		}
+
+		if len(args) > 0 {
 			if c == p.Command {
 				fmt.Fprintf(wr, "\nArguments:\n")
 			} else {
@@ -421,7 +428,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 
 			maxlen := aligninfo.descriptionStart()
 
-			for _, arg := range c.args {
+			for _, arg := range args {
 				prefix := strings.Repeat(" ", paddingBeforeOption)
 				fmt.Fprintf(wr, "%s%s", prefix, arg.Name)
 

--- a/help_test.go
+++ b/help_test.go
@@ -53,8 +53,9 @@ type helpOptions struct {
 	} `command:"hidden-command" description:"A hidden command" hidden:"yes"`
 
 	Args struct {
-		Filename string `positional-arg-name:"filename" description:"A filename"`
-		Number   int    `positional-arg-name:"num" description:"A number"`
+		Filename     string  `positional-arg-name:"filename" description:"A filename"`
+		Number       int     `positional-arg-name:"num" description:"A number"`
+		HiddenInHelp float32 `positional-arg-name:"hidden-in-help" required:"yes"`
 	} `positional-args:"yes"`
 }
 
@@ -84,7 +85,8 @@ func TestHelp(t *testing.T) {
 
 		if runtime.GOOS == "windows" {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] <command>
+  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <command>
+
 
 Application Options:
   /v, /verbose                              Show verbose debug information
@@ -129,7 +131,7 @@ Available commands:
 `
 		} else {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] <command>
+  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <command>
 
 Application Options:
   -v, --verbose                             Show verbose debug information

--- a/ini_test.go
+++ b/ini_test.go
@@ -21,7 +21,7 @@ func TestWriteIni(t *testing.T) {
 		expected string
 	}{
 		{
-			[]string{"-vv", "--intmap=a:2", "--intmap", "b:3", "filename", "0", "command"},
+			[]string{"-vv", "--intmap=a:2", "--intmap", "b:3", "filename", "0", "3.14", "command"},
 			IniDefault,
 			`[Application Options]
 ; Show verbose debug information
@@ -42,7 +42,7 @@ int-map = b:3
 `,
 		},
 		{
-			[]string{"-vv", "--intmap=a:2", "--intmap", "b:3", "filename", "0", "command"},
+			[]string{"-vv", "--intmap=a:2", "--intmap", "b:3", "filename", "0", "3.14", "command"},
 			IniDefault | IniIncludeDefaults,
 			`[Application Options]
 ; Show verbose debug information
@@ -104,7 +104,7 @@ Opt =
 `,
 		},
 		{
-			[]string{"filename", "0", "command"},
+			[]string{"filename", "0", "3.14", "command"},
 			IniDefault | IniIncludeDefaults | IniCommentDefaults,
 			`[Application Options]
 ; Show verbose debug information
@@ -164,7 +164,7 @@ EnvDefault2 = env-def
 `,
 		},
 		{
-			[]string{"--default=New value", "--default-array=New value", "--default-map=new:value", "filename", "0", "command"},
+			[]string{"--default=New value", "--default-array=New value", "--default-map=new:value", "filename", "0", "3.14", "command"},
 			IniDefault | IniIncludeDefaults | IniCommentDefaults,
 			`[Application Options]
 ; Show verbose debug information


### PR DESCRIPTION
This patch tweaks the behavior of --help so that positional arguments
that don't have a description are not listed. This allows certain
applications, that include a separate description of what each
positional argument does, to suppress otherwise duplicated help entry.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>