### PR TITLE
Option new methods

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -58,6 +58,8 @@ const (
 // IniParser is a utility to read and write flags options from and to ini
 // formatted strings.
 type IniParser struct {
+	ParseAsDefaults bool // override default flags
+
 	parser *Parser
 }
 
@@ -539,9 +541,9 @@ func (i *IniParser) parse(ini *ini) error {
 				continue
 			}
 
-			// ini value is ignored if override is not set or
+			// ini value is ignored if override is set and
 			// value was previously set from non default
-			if len(opt.tag.Get("ini-override")) > 0 && !opt.isSetDefault {
+			if i.ParseAsDefaults && !opt.isSetDefault {
 				continue
 			}
 

--- a/ini.go
+++ b/ini.go
@@ -539,6 +539,12 @@ func (i *IniParser) parse(ini *ini) error {
 				continue
 			}
 
+			// ini value is ignored if override is not set or
+			// value was previously set from non default
+			if len(opt.tag.Get("ini-override")) > 0 && !opt.isSetDefault {
+				continue
+			}
+
 			pval := &inival.Value
 
 			if !opt.canArgument() && len(inival.Value) == 0 {

--- a/ini_test.go
+++ b/ini_test.go
@@ -953,6 +953,7 @@ func TestIniOverwriteOptions(t *testing.T) {
 	var tests = []struct {
 		args     []string
 		expected string
+		toggled  bool
 	}{
 		{
 			args:     []string{},
@@ -965,14 +966,22 @@ func TestIniOverwriteOptions(t *testing.T) {
 		{
 			args:     []string{"--config", "no file name"},
 			expected: "from INI",
+			toggled:  true,
 		},
 		{
 			args:     []string{"--value", "from CLI before", "--config", "no file name"},
 			expected: "from CLI before",
+			toggled:  true,
 		},
 		{
 			args:     []string{"--config", "no file name", "--value", "from CLI after"},
 			expected: "from CLI after",
+			toggled:  true,
+		},
+		{
+			args:     []string{"--toggle"},
+			toggled:  true,
+			expected: "from default",
 		},
 	}
 
@@ -980,6 +989,7 @@ func TestIniOverwriteOptions(t *testing.T) {
 		var opts struct {
 			Config string `long:"config" no-ini:"true"`
 			Value  string `long:"value" default:"from default" ini-override:"true"`
+			Toggle bool   `long:"toggle" ini-override:"true"`
 		}
 
 		p := NewParser(&opts, Default)
@@ -990,7 +1000,7 @@ func TestIniOverwriteOptions(t *testing.T) {
 		}
 
 		if opts.Config != "" {
-			err = NewIniParser(p).Parse(bytes.NewBufferString("value = from INI"))
+			err = NewIniParser(p).Parse(bytes.NewBufferString("value = from INI\ntoggle = true"))
 			if err != nil {
 				t.Fatalf("Unexpected error %s with args %+v", err, test.args)
 			}
@@ -998,6 +1008,10 @@ func TestIniOverwriteOptions(t *testing.T) {
 
 		if opts.Value != test.expected {
 			t.Fatalf("Expected Value to be \"%s\" but was \"%s\" with args %+v", test.expected, opts.Value, test.args)
+		}
+
+		if opts.Toggle != test.toggled {
+			t.Fatalf("Expected Toggle to be \"%v\" but was \"%v\" with args %+v", test.toggled, opts.Toggle, test.args)
 		}
 
 	}

--- a/ini_test.go
+++ b/ini_test.go
@@ -988,8 +988,8 @@ func TestIniOverwriteOptions(t *testing.T) {
 	for _, test := range tests {
 		var opts struct {
 			Config string `long:"config" no-ini:"true"`
-			Value  string `long:"value" default:"from default" ini-override:"true"`
-			Toggle bool   `long:"toggle" ini-override:"true"`
+			Value  string `long:"value" default:"from default"`
+			Toggle bool   `long:"toggle"`
 		}
 
 		p := NewParser(&opts, Default)
@@ -1000,7 +1000,10 @@ func TestIniOverwriteOptions(t *testing.T) {
 		}
 
 		if opts.Config != "" {
-			err = NewIniParser(p).Parse(bytes.NewBufferString("value = from INI\ntoggle = true"))
+			inip := NewIniParser(p)
+			inip.ParseAsDefaults = true
+
+			err = inip.Parse(bytes.NewBufferString("value = from INI\ntoggle = true"))
 			if err != nil {
 				t.Fatalf("Unexpected error %s with args %+v", err, test.args)
 			}

--- a/option.go
+++ b/option.go
@@ -79,9 +79,10 @@ type Option struct {
 	// Determines if the option will be always quoted in the INI output
 	iniQuote bool
 
-	tag                 multiTag
-	isSet, isSetDefault bool
-	preventDefault      bool
+	tag            multiTag
+	isSet          bool
+	isSetDefault   bool
+	preventDefault bool
 
 	defaultLiteral string
 }
@@ -271,6 +272,7 @@ func (option *Option) clearDefault() {
 	}
 
 	option.isSetDefault = true
+
 	if len(usedDefault) > 0 {
 		option.empty()
 

--- a/option.go
+++ b/option.go
@@ -79,11 +79,15 @@ type Option struct {
 	// Determines if the option will be always quoted in the INI output
 	iniQuote bool
 
-	tag            multiTag
-	isSet          bool
-	preventDefault bool
+	tag                 multiTag
+	isSet, isSetDefault bool
+	preventDefault      bool
 
 	defaultLiteral string
+}
+
+func (option *Option) Field() reflect.Value {
+	return option.value
 }
 
 // LongNameWithNamespace returns the option's long name with the group namespaces
@@ -170,6 +174,11 @@ func (option *Option) Value() interface{} {
 // IsSet returns true if option has been set
 func (option *Option) IsSet() bool {
 	return option.isSet
+}
+
+// IsSetDefault returns true if option has been set with its default value.
+func (option *Option) IsSetDefault() bool {
+	return option.isSetDefault
 }
 
 // Set the value of an option to the specified value. An error will be returned
@@ -266,6 +275,7 @@ func (option *Option) clearDefault() {
 
 		for _, d := range usedDefault {
 			option.set(&d)
+			option.isSetDefault = true
 		}
 	} else {
 		tp := option.value.Type()

--- a/option.go
+++ b/option.go
@@ -86,10 +86,6 @@ type Option struct {
 	defaultLiteral string
 }
 
-func (option *Option) Field() reflect.Value {
-	return option.value
-}
-
 // LongNameWithNamespace returns the option's long name with the group namespaces
 // prepended by walking up the option's group tree. Namespaces and the long name
 // itself are separated by the parser's namespace delimiter. If the long name is
@@ -174,11 +170,6 @@ func (option *Option) Value() interface{} {
 // IsSet returns true if option has been set
 func (option *Option) IsSet() bool {
 	return option.isSet
-}
-
-// IsSetDefault returns true if option has been set with its default value.
-func (option *Option) IsSetDefault() bool {
-	return option.isSetDefault
 }
 
 // Set the value of an option to the specified value. An error will be returned
@@ -272,10 +263,10 @@ func (option *Option) clearDefault() {
 
 	if len(usedDefault) > 0 {
 		option.empty()
+		option.isSetDefault = true
 
 		for _, d := range usedDefault {
 			option.set(&d)
-			option.isSetDefault = true
 		}
 	} else {
 		tp := option.value.Type()

--- a/option.go
+++ b/option.go
@@ -86,6 +86,10 @@ type Option struct {
 	defaultLiteral string
 }
 
+func (option *Option) Field() reflect.Value {
+	return option.value
+}
+
 // LongNameWithNamespace returns the option's long name with the group namespaces
 // prepended by walking up the option's group tree. Namespaces and the long name
 // itself are separated by the parser's namespace delimiter. If the long name is
@@ -170,6 +174,11 @@ func (option *Option) Value() interface{} {
 // IsSet returns true if option has been set
 func (option *Option) IsSet() bool {
 	return option.isSet
+}
+
+// IsSetDefault returns true if option has been set with its default value.
+func (option *Option) IsSetDefault() bool {
+	return option.isSetDefault
 }
 
 // Set the value of an option to the specified value. An error will be returned
@@ -267,6 +276,7 @@ func (option *Option) clearDefault() {
 
 		for _, d := range usedDefault {
 			option.set(&d)
+			option.isSetDefault = true
 		}
 	} else {
 		tp := option.value.Type()

--- a/option.go
+++ b/option.go
@@ -261,9 +261,9 @@ func (option *Option) clearDefault() {
 		}
 	}
 
+	option.isSetDefault = true
 	if len(usedDefault) > 0 {
 		option.empty()
-		option.isSetDefault = true
 
 		for _, d := range usedDefault {
 			option.set(&d)

--- a/option.go
+++ b/option.go
@@ -87,10 +87,6 @@ type Option struct {
 	defaultLiteral string
 }
 
-func (option *Option) Field() reflect.Value {
-	return option.value
-}
-
 // LongNameWithNamespace returns the option's long name with the group namespaces
 // prepended by walking up the option's group tree. Namespaces and the long name
 // itself are separated by the parser's namespace delimiter. If the long name is
@@ -175,11 +171,6 @@ func (option *Option) Value() interface{} {
 // IsSet returns true if option has been set
 func (option *Option) IsSet() bool {
 	return option.isSet
-}
-
-// IsSetDefault returns true if option has been set with its default value.
-func (option *Option) IsSetDefault() bool {
-	return option.isSetDefault
 }
 
 // Set the value of an option to the specified value. An error will be returned

--- a/parser.go
+++ b/parser.go
@@ -193,6 +193,7 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 
 	p.eachOption(func(c *Command, g *Group, option *Option) {
 		option.isSet = false
+		option.isSetDefault = false
 		option.updateDefaultLiteral()
 	})
 


### PR DESCRIPTION
Hopefully, this is helpful for everyone...

- added Option.Field() method to recover the struct field associated with the option
- added Option.IsSetDefault() to help distinguish cases where the option was really set or set with default values