### PR TITLE
Handle multi-line struct tags

### DIFF
--- a/multitag.go
+++ b/multitag.go
@@ -1,8 +1,6 @@
 package flags
 
-import (
-	"strconv"
-)
+import "strconv"
 
 type multiTag struct {
 	value string
@@ -15,6 +13,10 @@ func newMultiTag(v string) multiTag {
 	}
 }
 
+func isSpace(b byte) bool {
+	return b == ' ' || b == '\n' || b == '\t'
+}
+
 func (x *multiTag) scan() (map[string][]string, error) {
 	v := x.value
 
@@ -25,7 +27,7 @@ func (x *multiTag) scan() (map[string][]string, error) {
 		i := 0
 
 		// Skip whitespace
-		for i < len(v) && v[i] == ' ' {
+		for i < len(v) && isSpace(v[i]) {
 			i++
 		}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -16,7 +16,9 @@ type defaultOptions struct {
 	IntDefault int `long:"id" default:"1"`
 
 	Float64        float64 `long:"f"`
-	Float64Default float64 `long:"fd" default:"-3.14"`
+	Float64Default float64 `
+		long:"fd"
+		default:"-3.14"`
 
 	NumericFlag bool `short:"3"`
 


### PR DESCRIPTION
These tags can get really long with descriptions + long descriptions. go-flags is already using its own tag parsing so it's straightforward to allow newlines in these tags to help break them up. `go vet` will still complain about them, but that's a tradeoff I'm willing to make.

Thoughts?