### PR TITLE
Show group descriptions in man page output

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -215,6 +215,8 @@ TestMan \- Test manpage generation
 .SH DESCRIPTION
 This is a somewhat \fBlonger\fP description of what this does
 .SH OPTIONS
+.SS Application Options
+The application options
 .TP
 \fB\fB\-v\fR, \fB\-\-verbose\fR\fP
 Show verbose debug information
@@ -247,15 +249,18 @@ Option with named argument
 .TP
 \fB\fB\-\-opt-with-choices\fR \fIchoice\fR\fP
 Option with choices
+.SS Other Options
 .TP
 \fB\fB\-s\fR <default: \fI"some", "value"\fR>\fP
 A slice of strings
 .TP
 \fB\fB\-\-intmap\fR <default: \fI"a:1"\fR>\fP
 A map from string to int
+.SS Subgroup
 .TP
 \fB\fB\-\-sip.opt\fR\fP
 This is a subgroup option
+.SS Subsubgroup
 .TP
 \fB\fB\-\-sip.sap.opt\fR\fP
 This is a subsubgroup option

--- a/man.go
+++ b/man.go
@@ -42,8 +42,10 @@ func writeManPageOptions(wr io.Writer, grp *Group) {
 			return
 		}
 
-		if group.ShortDescription != "" {
-			fmt.Fprintf(wr, ".SH %s\n", group.ShortDescription)
+		// If the parent (grp) has any subgroups, display their descriptions as
+		// subsection headers similar to the output of --help.
+		if group.ShortDescription != "" && len(grp.groups) > 0 {
+			fmt.Fprintf(wr, ".SS %s\n", group.ShortDescription)
 
 			if group.LongDescription != "" {
 				formatForMan(wr, group.LongDescription)

--- a/man.go
+++ b/man.go
@@ -38,8 +38,17 @@ func formatForMan(wr io.Writer, s string) {
 
 func writeManPageOptions(wr io.Writer, grp *Group) {
 	grp.eachGroup(func(group *Group) {
-		if group.Hidden {
+		if group.Hidden || len(group.options) == 0 {
 			return
+		}
+
+		if group.ShortDescription != "" {
+			fmt.Fprintf(wr, ".SH %s\n", group.ShortDescription)
+
+			if group.LongDescription != "" {
+				formatForMan(wr, group.LongDescription)
+				fmt.Fprintln(wr, "")
+			}
 		}
 
 		for _, opt := range group.options {


### PR DESCRIPTION
Currently if you have groups defined `--help` will show something like
```
Application Options:
      --foo       Bar

Other Options:
      --bar       Baz
```

but in the groff generated by `WriteManPage` this gets rendered as

```
      --foo       Bar
      --bar       Baz
```

With this change the man page renders more like the `--help` output, plus descriptions for the groupings.

I'm inexperienced with groff so tell me if the formatting is bad.