### PR TITLE
Also wrap argument descriptions

### DIFF
--- a/help.go
+++ b/help.go
@@ -426,15 +426,27 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 				fmt.Fprintf(wr, "\n[%s command arguments]\n", c.Name)
 			}
 
-			maxlen := aligninfo.descriptionStart()
+			descStart := aligninfo.descriptionStart() + paddingBeforeOption
 
 			for _, arg := range args {
-				prefix := strings.Repeat(" ", paddingBeforeOption)
-				fmt.Fprintf(wr, "%s%s", prefix, arg.Name)
+				argPrefix := strings.Repeat(" ", paddingBeforeOption)
+				argPrefix += arg.Name
 
 				if len(arg.Description) > 0 {
-					align := strings.Repeat(" ", maxlen-len(arg.Name)-1)
-					fmt.Fprintf(wr, ":%s%s", align, arg.Description)
+					argPrefix += ":"
+					wr.WriteString(argPrefix)
+
+					// Space between "arg:" and the description start
+					descPadding := strings.Repeat(" ", descStart-len(argPrefix))
+					// How much space the description gets before wrapping
+					descWidth := aligninfo.terminalColumns - 1 - descStart
+					// Whitespace to which we can indent new description lines
+					descPrefix := strings.Repeat(" ", descStart)
+
+					wr.WriteString(descPadding)
+					wr.WriteString(wrapText(arg.Description, descWidth, descPrefix))
+				} else {
+					wr.WriteString(argPrefix)
 				}
 
 				fmt.Fprintln(wr)

--- a/help_test.go
+++ b/help_test.go
@@ -53,7 +53,7 @@ type helpOptions struct {
 	} `command:"hidden-command" description:"A hidden command" hidden:"yes"`
 
 	Args struct {
-		Filename     string  `positional-arg-name:"filename" description:"A filename"`
+		Filename     string  `positional-arg-name:"filename" description:"A filename with a long description to trigger line wrapping"`
 		Number       int     `positional-arg-name:"num" description:"A number"`
 		HiddenInHelp float32 `positional-arg-name:"hidden-in-help" required:"yes"`
 	} `positional-args:"yes"`
@@ -167,7 +167,8 @@ Help Options:
   -h, --help                                Show this help message
 
 Arguments:
-  filename:                                 A filename
+  filename:                                 A filename with a long description
+                                            to trigger line wrapping
   num:                                      A number
 
 Available commands:


### PR DESCRIPTION
`wrapText` wasn't getting called on `arg.Description`.