### PR TITLE
Allow forcing posix style flags on Windows

### DIFF
--- a/optstyle_other.go
+++ b/optstyle_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows forceposix
 
 package flags
 

--- a/optstyle_windows.go
+++ b/optstyle_windows.go
@@ -1,3 +1,5 @@
+// +build !forceposix
+
 package flags
 
 import (


### PR DESCRIPTION
We've recently switched from a custom parsing library to go-flags and we're trying to support a use case where we have a built in `curl` command that accepts a relative URL: `cf curl /v2/info` However, on Windows, this command is failing across the board due to PR #39.

By using `go build -tags "forceposix" <package>` when compiling for Windows it will remove support for the Windows style flag parsing, enabling use of slash (`/`) as the first character of a positional argument.