### PR TITLE
fix failing test on windows

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -87,7 +87,6 @@ func TestHelp(t *testing.T) {
 			expected = `Usage:
   TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <command>
 
-
 Application Options:
   /v, /verbose                              Show verbose debug information
   /c:                                       Call phone number
@@ -123,7 +122,8 @@ Help Options:
   /h, /help                                 Show this help message
 
 Arguments:
-  filename:                                 A filename
+  filename:                                 A filename with a long description
+                                            to trigger line wrapping
   num:                                      A number
 
 Available commands:


### PR DESCRIPTION
This pull requests fixes tests on Windows - just correcting the test assertions that were missed for the Windows build in these commits:

742a7f1b56a5e74fb1c5c6717a4a3812db3ab10f
8b13cca09c34bf4d82080e4ee3ab3cc7d50f8277
