### PR TITLE
allow tags spanning to multiple lines for a clear layout

### DIFF
--- a/multitag.go
+++ b/multitag.go
@@ -25,7 +25,7 @@ func (x *multiTag) scan() (map[string][]string, error) {
 		i := 0
 
 		// Skip whitespace
-		for i < len(v) && v[i] == ' ' {
+		for i < len(v) && (v[i] == ' ' || v[i] == '\t' || v[i] == '\n') {
 			i++
 		}
 
@@ -38,7 +38,7 @@ func (x *multiTag) scan() (map[string][]string, error) {
 		// Scan to colon to find key
 		i = 0
 
-		for i < len(v) && v[i] != ' ' && v[i] != ':' && v[i] != '"' {
+		for i < len(v) && v[i] != ' ' && v[i] != '\t' && v[i] != '\n' && v[i] != ':' && v[i] != '"' {
 			i++
 		}
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -36,3 +36,28 @@ something"`
 
 	assertParseFail(t, ErrTag, "unexpected newline in tag value `description' (in `long:\"verbose\" description:\"verbose\nsomething\"`)", &opts, "")
 }
+
+func TestTagMultiline(t *testing.T) {
+	type Opts struct {
+		Value int `
+			long:"value"
+			default:"41"
+			description:"value of something"`
+	}
+
+	{
+		var opts Opts
+		assertParseSuccess(t, &opts, "--value=42")
+		if opts.Value != 42 {
+			t.Fatal("expect value to be 42")
+		}
+	}
+
+	{
+		var opts Opts
+		assertParseSuccess(t, &opts, "")
+		if opts.Value != 41 {
+			t.Fatalf("expect value %d to be 41", opts.Value)
+		}
+	}
+}


### PR DESCRIPTION
This PR allows tags spanning to multiple lines for a clear layout. A test case for this feature is also added.
