### PR TITLE
Do not change the value of non-tagged fields

### DIFF
--- a/group.go
+++ b/group.go
@@ -213,12 +213,18 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 				return err
 			}
 		} else if kind == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
+			flagCountBefore := len(g.options) + len(g.groups)
+
 			if fld.IsNil() {
-				fld.Set(reflect.New(fld.Type().Elem()))
+				fld = reflect.New(fld.Type().Elem())
 			}
 
 			if err := g.scanStruct(reflect.Indirect(fld), &field, handler); err != nil {
 				return err
+			}
+
+			if len(g.options)+len(g.groups) != flagCountBefore {
+				realval.Field(i).Set(fld)
 			}
 		}
 

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -79,3 +79,28 @@ func TestPointerGroup(t *testing.T) {
 		t.Errorf("Expected Group.Value to be true")
 	}
 }
+
+func TestDoNotChangeNonTaggedFields(t *testing.T) {
+	var opts struct {
+		A struct {
+			Pointer *int
+		}
+		B *struct {
+			Pointer *int
+		}
+	}
+
+	ret := assertParseSuccess(t, &opts)
+
+	assertStringArray(t, ret, []string{})
+
+	if opts.A.Pointer != nil {
+		t.Error("Expected A.Pointer to be nil")
+	}
+	if opts.B != nil {
+		t.Error("Expected B to be nil")
+	}
+	if opts.B != nil && opts.B.Pointer != nil {
+		t.Error("Expected B.Pointer to be nil")
+	}
+}


### PR DESCRIPTION
Every field of a struct that is given to go-flags is parsed for flags. This is done by recursively going through all fields. If a struct type is encountered go-flags makes sure that it has a value so found flags can be safely assigned the parsed flag values. However, this opens the problem that pointer struct fields are initialized even if they do not own any flag-related field. This PR changes the behavior so that these fields with a pointer struct type are not assigned a value, and therefore stay nil.

I tried to keep most of the original behavior that is why the PR checks for changed in g.groups too. If the PR would not do this TestPointerGroup would fail. Also, I put the test inside of pointer_test.go because only struct pointers are affected.