### PR TITLE
Always support the two latest Go releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.6
+  - 1.6.x
+  - 1.7.x
 
 install:
   # go-flags


### PR DESCRIPTION
I think we should always test with the two latest Go releases. This will cover most people's upgrade strategies.

The "x" is a nice feature I only recently saw in the documentation :+1: 