### PR TITLE
Support MacOSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
   - 1.6
 


### PR DESCRIPTION
It is rather easy to support MacOSX using TravisCI. Altough I do not own an Apple product a lot of other developers do and therefore I think it is worth to support that environment too.