### PR TITLE
Completion on short option names allows for exploration of short and long option names

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -101,7 +101,30 @@ func (c *completion) completeShortNames(s *parseState, prefix string, match stri
 		}
 	}
 
-	return c.completeOptionNames(s.lookup.shortNames, prefix, match)
+	var results []Completion
+	repeats := map[string]bool{}
+
+	for name, opt := range s.lookup.longNames {
+		if !opt.Hidden {
+			results = append(results, Completion{
+				Item:        "--" + name,
+				Description: opt.Description,
+			})
+
+			repeats[string(opt.ShortName)] = true
+		}
+	}
+
+	for name, opt := range s.lookup.shortNames {
+		if _, exist := repeats[name]; !exist && !opt.Hidden {
+			results = append(results, Completion{
+				Item:        "-" + name,
+				Description: opt.Description,
+			})
+		}
+	}
+
+	return results
 }
 
 func (c *completion) completeCommands(s *parseState, match string) []Completion {

--- a/completion.go
+++ b/completion.go
@@ -88,7 +88,7 @@ func (c *completion) completeOptionNames(s *parseState, prefix string, match str
 	for name, opt := range s.lookup.longNames {
 		if strings.HasPrefix(name, match) && !opt.Hidden {
 			results = append(results, Completion{
-				Item:        "--" + name,
+				Item:        defaultLongOptDelimiter + name,
 				Description: opt.Description,
 			})
 
@@ -102,7 +102,7 @@ func (c *completion) completeOptionNames(s *parseState, prefix string, match str
 		for name, opt := range s.lookup.shortNames {
 			if _, exist := repeats[name]; !exist && strings.HasPrefix(name, match) && !opt.Hidden {
 				results = append(results, Completion{
-					Item:        "-" + name,
+					Item:        string(defaultShortOptDelimiter) + name,
 					Description: opt.Description,
 				})
 			}

--- a/completion_test.go
+++ b/completion_test.go
@@ -88,6 +88,13 @@ func init() {
 		},
 
 		{
+			// Short names full
+			[]string{"-i"},
+			[]string{"-i"},
+			false,
+		},
+
+		{
 			// Short names concatenated
 			[]string{"-dv"},
 			[]string{"-dv"},

--- a/completion_test.go
+++ b/completion_test.go
@@ -38,6 +38,7 @@ func (t *TestComplete) Complete(match string) []Completion {
 var completionTestOptions struct {
 	Verbose  bool `short:"v" long:"verbose" description:"Verbose messages"`
 	Debug    bool `short:"d" long:"debug" description:"Enable debug"`
+	Info     bool `short:"i" description:"Display info"`
 	Version  bool `long:"version" description:"Show version"`
 	Required bool `long:"required" required:"true" description:"This is required"`
 	Hidden   bool `long:"hidden" hidden:"true" description:"This is hidden"`
@@ -82,7 +83,7 @@ func init() {
 		{
 			// Short names
 			[]string{"-"},
-			[]string{"-d", "-v"},
+			[]string{"--debug", "--required", "--verbose", "--version", "-i"},
 			false,
 		},
 


### PR DESCRIPTION
This PR addresses feature request #224.

- previously it would return only a list of short option names
- now it returns both short and long option names; in the case when an
option has both a short and long name, it will return only the long name