### PR TITLE
Correctly handle `default-mask:"-"`

### DIFF
--- a/help.go
+++ b/help.go
@@ -216,8 +216,10 @@ func (p *Parser) writeHelpOption(writer *bufio.Writer, option *Option, info alig
 
 		var def string
 
-		if len(option.DefaultMask) != 0 && option.DefaultMask != "-" {
-			def = option.DefaultMask
+		if len(option.DefaultMask) != 0 {
+			if option.DefaultMask != "-" {
+				def = option.DefaultMask
+			}
 		} else {
 			def = option.defaultLiteral
 		}


### PR DESCRIPTION
Fix the help not to leak default values of options with `default-mask:"-"`.