### PR TITLE
Don't crash if subcommand has no commands of its own

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -479,7 +479,7 @@ func (p *parseState) estimateCommand() error {
 			msg = fmt.Sprintf("%s. You should use the %s command",
 				msg,
 				cmdnames[0])
-		} else {
+		} else if len(cmdnames) > 1 {
 			msg = fmt.Sprintf("%s. Please specify one command of: %s or %s",
 				msg,
 				strings.Join(cmdnames[:len(cmdnames)-1], ", "),
@@ -490,7 +490,7 @@ func (p *parseState) estimateCommand() error {
 
 		if len(cmdnames) == 1 {
 			msg = fmt.Sprintf("Please specify the %s command", cmdnames[0])
-		} else {
+		} else if len(cmdnames) > 1 {
 			msg = fmt.Sprintf("Please specify one command of: %s or %s",
 				strings.Join(cmdnames[:len(cmdnames)-1], ", "),
 				cmdnames[len(cmdnames)-1])


### PR DESCRIPTION
Adding a subcommand parser and then defining no commands on it can crash
estimatedCommands() since cmdnames is empty but the code assumes it is
at least one element long. This patch adds an explicit check for that.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>