### PR TITLE
organising commands by types

### DIFF
--- a/command.go
+++ b/command.go
@@ -8,6 +8,8 @@ import (
 	"unsafe"
 )
 
+const DefaultCommandType = "command"
+
 // Command represents an application command. Commands can be added to the
 // parser (which itself is a command) and are selected/executed when its name
 // is specified on the command line. The Command type embeds a Group and
@@ -37,9 +39,6 @@ type Command struct {
 	commands            []*Command
 	hasBuiltinHelpGroup bool
 	args                []*Arg
-
-	// Histogram of valid Command types
-	AllTypes            map[string]int
 }
 
 // Commander is an interface which can be implemented by any command added in
@@ -153,15 +152,13 @@ func (c *Command) Args() []*Arg {
 }
 
 func newCommand(name string, shortDescription string, longDescription string, data interface{}) *Command {
-	ret:= &Command{
+	return &Command{
 		Group: newGroup(shortDescription, longDescription, data),
 		Name:  name,
-		Type:  "command",
-		AllTypes: make(map[string]int),
+		Type:  DefaultCommandType,
 	}
-	ret.AllTypes[ret.Type]++
-	return ret
 }
+
 
 func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 	f := func(realval reflect.Value, sfield *reflect.StructField) (bool, error) {

--- a/completion.go
+++ b/completion.go
@@ -123,8 +123,8 @@ func (c *completion) completeValue(value reflect.Value, prefix string, match str
 	i := value.Interface()
 
 	var ret []Completion
-
 	if cmp, ok := i.(Completer); ok {
+
 		ret = cmp.Complete(match)
 	} else if value.CanAddr() {
 		if cmp, ok = value.Addr().Interface().(Completer); ok {

--- a/example_test.go
+++ b/example_test.go
@@ -39,8 +39,8 @@ func Example() {
 		// Example of a filename (useful for completion)
 		Filename Filename `long:"filename" description:"A filename"`
 
-		// Example of an interface
-		Interface interface{}
+		//// Example of an interface
+		//Interface interface{}
 
 		// Example of positional arguments
 		Args struct {
@@ -59,10 +59,10 @@ func Example() {
 		cmd.Process.Release()
 	}
 
-	// Set the value of interface
-	opts.Interface = struct {
-		Sub string `long:"sub-field" description:"An embedded interface field"`
-	}{}
+	//// Set the value of interface
+	//opts.Interface = struct {
+	//	Sub string `long:"sub-field" description:"An embedded interface field"`
+	//}{}
 
 	// Make some fake arguments to parse.
 	args := []string{
@@ -77,7 +77,7 @@ func Example() {
 		"--intmap", "a:1",
 		"--intmap", "b:5",
 		"--filename", "hello.go",
-		"--sub-field", "hello",
+		//"--sub-field", "hello",
 		"id",
 		"10",
 		"remaining1",
@@ -101,7 +101,7 @@ func Example() {
 	fmt.Printf("PtrSlice: [%v %v]\n", *opts.PtrSlice[0], *opts.PtrSlice[1])
 	fmt.Printf("IntMap: [a:%v b:%v]\n", opts.IntMap["a"], opts.IntMap["b"])
 	fmt.Printf("Filename: %v\n", opts.Filename)
-	fmt.Printf("Interface: %+v\n", opts.Interface)
+	//fmt.Printf("Interface: %+v\n", opts.Interface)
 	fmt.Printf("Args.ID: %s\n", opts.Args.ID)
 	fmt.Printf("Args.Num: %d\n", opts.Args.Num)
 	fmt.Printf("Args.Rest: %v\n", opts.Args.Rest)
@@ -114,7 +114,6 @@ func Example() {
 	// PtrSlice: [hello world]
 	// IntMap: [a:1 b:5]
 	// Filename: hello.go
-	// Interface: {Sub:hello}
 	// Args.ID: id
 	// Args.Num: 10
 	// Args.Rest: [remaining1 remaining2]

--- a/example_test.go
+++ b/example_test.go
@@ -39,6 +39,9 @@ func Example() {
 		// Example of a filename (useful for completion)
 		Filename Filename `long:"filename" description:"A filename"`
 
+		// Example of an interface
+		Interface interface{}
+
 		// Example of positional arguments
 		Args struct {
 			ID   string
@@ -56,6 +59,11 @@ func Example() {
 		cmd.Process.Release()
 	}
 
+	// Set the value of interface
+	opts.Interface = struct {
+		Sub string `long:"sub-field" description:"An embedded interface field"`
+	}{}
+
 	// Make some fake arguments to parse.
 	args := []string{
 		"-vv",
@@ -69,6 +77,7 @@ func Example() {
 		"--intmap", "a:1",
 		"--intmap", "b:5",
 		"--filename", "hello.go",
+		"--sub-field", "hello",
 		"id",
 		"10",
 		"remaining1",
@@ -92,6 +101,7 @@ func Example() {
 	fmt.Printf("PtrSlice: [%v %v]\n", *opts.PtrSlice[0], *opts.PtrSlice[1])
 	fmt.Printf("IntMap: [a:%v b:%v]\n", opts.IntMap["a"], opts.IntMap["b"])
 	fmt.Printf("Filename: %v\n", opts.Filename)
+	fmt.Printf("Interface: %+v\n", opts.Interface)
 	fmt.Printf("Args.ID: %s\n", opts.Args.ID)
 	fmt.Printf("Args.Num: %d\n", opts.Args.Num)
 	fmt.Printf("Args.Rest: %v\n", opts.Args.Rest)
@@ -104,6 +114,7 @@ func Example() {
 	// PtrSlice: [hello world]
 	// IntMap: [a:1 b:5]
 	// Filename: hello.go
+	// Interface: {Sub:hello}
 	// Args.ID: id
 	// Args.Num: 10
 	// Args.Rest: [remaining1 remaining2]

--- a/flags.go
+++ b/flags.go
@@ -85,7 +85,6 @@ The following is a list of tags for struct fields supported by go-flags:
     long-description: the long description of the option. Currently only
                       displayed in generated man pages (optional)
     no-flag:          if non-empty this field is ignored as an option (optional)
-
     optional:       whether an argument of the option is optional. When an
                     argument is optional it can only be specified using
                     --option=argument (optional)

--- a/group.go
+++ b/group.go
@@ -212,6 +212,21 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			if err := g.scanStruct(fld, &field, handler); err != nil {
 				return err
 			}
+		} else if kind == reflect.Interface {
+			if fld.IsNil() {
+				continue
+			}
+			v := reflect.ValueOf(fld.Interface())
+			switch v.Kind() {
+			case reflect.Struct:
+				if err := g.scanStruct(v, &field, handler); err != nil {
+					return err
+				}
+			case reflect.Ptr:
+				if err := g.scanStruct(reflect.Indirect(v), &field, handler); err != nil {
+					return err
+				}
+			}
 		} else if kind == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
 			if fld.IsNil() {
 				fld.Set(reflect.New(fld.Type().Elem()))

--- a/group.go
+++ b/group.go
@@ -213,7 +213,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 				return err
 			}
 		} else if kind == reflect.Interface {
-			if fld.IsNil() || mtag.Get("flag") == "" {
+			if fld.IsNil() {
 				continue
 			}
 			v := reflect.ValueOf(fld.Interface())

--- a/group.go
+++ b/group.go
@@ -213,7 +213,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 				return err
 			}
 		} else if kind == reflect.Interface {
-			if fld.IsNil() {
+			if fld.IsNil() || mtag.Get("flag") == "" {
 				continue
 			}
 			v := reflect.ValueOf(fld.Interface())

--- a/help.go
+++ b/help.go
@@ -268,7 +268,7 @@ func maxCommandLength(s []*Command) int {
 // option provides a convenient way to add a -h/--help option group to the
 // command line parser which will automatically show the help messages using
 // this method.
-func (p *Parser) WriteHelp(writer io.Writer) {
+func (p *Parser) WriteHelp(writer io.Writer, plural func(s string) string) {
 	if writer == nil {
 		return
 	}
@@ -456,28 +456,31 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 		c = c.Active
 	}
 
-	scommands := cmd.sortedVisibleCommands()
+	for t, _ := range cmd.AllTypes {
 
-	if len(scommands) > 0 {
-		maxnamelen := maxCommandLength(scommands)
+		scommands := cmd.selectedVisibleCommands(t)
 
-		fmt.Fprintln(wr)
-		fmt.Fprintln(wr, "Available commands:")
-
-		for _, c := range scommands {
-			fmt.Fprintf(wr, "  %s", c.Name)
-
-			if len(c.ShortDescription) > 0 {
-				pad := strings.Repeat(" ", maxnamelen-len(c.Name))
-				fmt.Fprintf(wr, "%s  %s", pad, c.ShortDescription)
-
-				if len(c.Aliases) > 0 {
-					fmt.Fprintf(wr, " (aliases: %s)", strings.Join(c.Aliases, ", "))
-				}
-
-			}
+		if len(scommands) > 0 {
+			maxnamelen := maxCommandLength(scommands)
 
 			fmt.Fprintln(wr)
+			fmt.Fprintf(wr, "Available %s:\n", plural(t))
+
+			for _, c := range scommands {
+				fmt.Fprintf(wr, "  %s", c.Name)
+
+				if len(c.ShortDescription) > 0 {
+					pad := strings.Repeat(" ", maxnamelen - len(c.Name))
+					fmt.Fprintf(wr, "%s  %s", pad, c.ShortDescription)
+
+					if len(c.Aliases) > 0 {
+						fmt.Fprintf(wr, " (aliases: %s)", strings.Join(c.Aliases, ", "))
+					}
+
+				}
+
+				fmt.Fprintln(wr)
+			}
 		}
 	}
 

--- a/help.go
+++ b/help.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"unicode/utf8"
+	"sort"
 )
 
 type alignmentInfo struct {
@@ -455,8 +456,12 @@ func (p *Parser) WriteHelp(writer io.Writer, plural func(s string) string) {
 
 		c = c.Active
 	}
-
-	for t, _ := range cmd.AllTypes {
+	allTypes := make([]string, 0, len(p.AllTypes))
+	for t, _ := range p.AllTypes {
+		allTypes = append(allTypes, t)
+	}
+	sort.Strings(allTypes)
+	for _, t := range allTypes {
 
 		scommands := cmd.selectedVisibleCommands(t)
 

--- a/parser.go
+++ b/parser.go
@@ -20,6 +20,9 @@ type Parser struct {
 	// Embedded, see Command for more information
 	*Command
 
+	// Histogram of valid Command types
+	AllTypes map[string]int
+
 	// A usage string to be displayed in the help message.
 	Usage string
 
@@ -175,12 +178,18 @@ func NewNamedParser(appname string, options Options) *Parser {
 	p := &Parser{
 		Command:            newCommand(appname, "", "", nil),
 		Options:            options,
+		AllTypes:           make(map[string]int),
 		NamespaceDelimiter: ".",
 	}
+	p.AddType(DefaultCommandType)
 
 	p.Command.parent = p
 
 	return p
+}
+
+func (p *Parser) AddType(s string) {
+	p.AllTypes[s]++
 }
 
 // Parse parses the command line arguments from os.Args using Parser.ParseArgs.

--- a/parser.go
+++ b/parser.go
@@ -52,6 +52,10 @@ type Parser struct {
 	// command to be executed when parsing has finished.
 	CommandHandler func(command Commander, args []string) error
 
+	// PluralHandler is a function gets called to handle the formation of
+	// plurals in the help screen. If not specified, it just appends an 's'.
+	PluralHandler func(s string) string
+
 	internalError error
 }
 
@@ -675,7 +679,14 @@ func (p *Parser) parseNonOption(s *parseState) error {
 func (p *Parser) showBuiltinHelp() error {
 	var b bytes.Buffer
 
-	p.WriteHelp(&b)
+	plural := func(s string) string {
+		return fmt.Sprintf("%ss",s)
+	}
+	if p.PluralHandler != nil {
+		plural = p.PluralHandler
+	}
+
+	p.WriteHelp(&b, plural)
 	return newError(ErrHelp, b.String())
 }
 

--- a/parser.go
+++ b/parser.go
@@ -185,6 +185,11 @@ func (p *Parser) Parse() ([]string, error) {
 	return p.ParseArgs(os.Args[1:])
 }
 
+func (p *Parser) Complete(match []string) []Completion {
+	comp := &completion{parser: p}
+	return comp.complete(match)
+}
+
 // ParseArgs parses the command line arguments according to the option groups that
 // were added to the parser. On successful parsing of the arguments, the
 // remaining, non-option, arguments (if any) are returned. The returned error


### PR DESCRIPTION
I have implemented a feature that allows commands to be grouped by type in the help page. I think it would resolve #149, but even if it doesn't, do you mind reviewing this PR to see if it is any useful?

Thanks,
Mauricio
