### PR TITLE
Remove unreachable os.Exit call from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ args, err := flags.ParseArgs(&opts, args)
 
 if err != nil {
 	panic(err)
-	os.Exit(1)
 }
 
 fmt.Printf("Verbosity: %v\n", opts.Verbose)


### PR DESCRIPTION
Non-essential change but would avoid compiler warnings if code was copy-pasted and compiled.