### PR TITLE
Add filepath as an equivalent to filename which completes into subdirs.

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -48,6 +49,9 @@ type completion struct {
 // Filename is a string alias which provides filename completion.
 type Filename string
 
+// Filepath is a string alias which provides completion for file paths into subdirectories.
+type Filepath string
+
 func completionsWithoutDescriptions(items []string) []Completion {
 	ret := make([]Completion, len(items))
 
@@ -62,6 +66,18 @@ func completionsWithoutDescriptions(items []string) []Completion {
 // prefix.
 func (f *Filename) Complete(match string) []Completion {
 	ret, _ := filepath.Glob(match + "*")
+	return completionsWithoutDescriptions(ret)
+}
+
+// Complete returns a list of existing files with the given prefix.
+// If it completes to a single directory, the contents of that directory are interrogated.
+func (f *Filepath) Complete(match string) []Completion {
+	ret, _ := filepath.Glob(match + "*")
+	if len(ret) == 1 {
+		if info, err := os.Stat(ret[0]); err == nil && info.IsDir() {
+			ret, _ = filepath.Glob(ret[0] + "/*")
+		}
+	}
 	return completionsWithoutDescriptions(ret)
 }
 

--- a/completion.go
+++ b/completion.go
@@ -65,7 +65,7 @@ func (f *Filename) Complete(match string) []Completion {
 	ret, _ := filepath.Glob(match + "*")
 	if len(ret) == 1 {
 		if info, err := os.Stat(ret[0]); err == nil && info.IsDir() {
-			ret, _ = filepath.Glob(ret[0] + "/*")
+			return f.Complete(ret[0] + "/")
 		}
 	}
 	return completionsWithoutDescriptions(ret)

--- a/completion.go
+++ b/completion.go
@@ -49,9 +49,6 @@ type completion struct {
 // Filename is a string alias which provides filename completion.
 type Filename string
 
-// Filepath is a string alias which provides completion for file paths into subdirectories.
-type Filepath string
-
 func completionsWithoutDescriptions(items []string) []Completion {
 	ret := make([]Completion, len(items))
 
@@ -65,13 +62,6 @@ func completionsWithoutDescriptions(items []string) []Completion {
 // Complete returns a list of existing files with the given
 // prefix.
 func (f *Filename) Complete(match string) []Completion {
-	ret, _ := filepath.Glob(match + "*")
-	return completionsWithoutDescriptions(ret)
-}
-
-// Complete returns a list of existing files with the given prefix.
-// If it completes to a single directory, the contents of that directory are interrogated.
-func (f *Filepath) Complete(match string) []Completion {
 	ret, _ := filepath.Glob(match + "*")
 	if len(ret) == 1 {
 		if info, err := os.Stat(ret[0]); err == nil && info.IsDir() {

--- a/completion_test.go
+++ b/completion_test.go
@@ -63,7 +63,6 @@ var completionTestOptions struct {
 	RemoveCommand struct {
 		Other bool     `short:"o"`
 		File  Filename `short:"f" long:"filename"`
-		Dir   Filepath `short:"d" long:"dir"`
 	} `command:"rm" description:"remove an item"`
 
 	RenameCommand struct {
@@ -85,7 +84,7 @@ func init() {
 
 	completionTestFilename := []string{filepath.Join(completionTestSourcedir, "completion.go"), filepath.Join(completionTestSourcedir, "completion_test.go")}
 
-	completionTestFilepath := []string{
+	completionTestSubdir := []string{
 		filepath.Join(completionTestSourcedir, "examples/add.go"),
 		filepath.Join(completionTestSourcedir, "examples/bash-completion"),
 		filepath.Join(completionTestSourcedir, "examples/main.go"),
@@ -236,16 +235,9 @@ func init() {
 		},
 
 		{
-			// Flag filepath file
-			[]string{"rm", "-d", path.Join(completionTestSourcedir, "completion")},
-			completionTestFilename,
-			false,
-		},
-
-		{
-			// Flag filepath dir
-			[]string{"rm", "-d", path.Join(completionTestSourcedir, "examples")},
-			completionTestFilepath,
+			// Subdirectory
+			[]string{"rm", "--filename", path.Join(completionTestSourcedir, "examples")},
+			completionTestSubdir,
 			false,
 		},
 

--- a/completion_test.go
+++ b/completion_test.go
@@ -63,6 +63,7 @@ var completionTestOptions struct {
 	RemoveCommand struct {
 		Other bool     `short:"o"`
 		File  Filename `short:"f" long:"filename"`
+		Dir   Filepath `short:"d" long:"dir"`
 	} `command:"rm" description:"remove an item"`
 
 	RenameCommand struct {
@@ -83,6 +84,13 @@ func init() {
 	completionTestSourcedir := filepath.Join(filepath.SplitList(path.Dir(sourcefile))...)
 
 	completionTestFilename := []string{filepath.Join(completionTestSourcedir, "completion.go"), filepath.Join(completionTestSourcedir, "completion_test.go")}
+
+	completionTestFilepath := []string{
+		filepath.Join(completionTestSourcedir, "examples/add.go"),
+		filepath.Join(completionTestSourcedir, "examples/bash-completion"),
+		filepath.Join(completionTestSourcedir, "examples/main.go"),
+		filepath.Join(completionTestSourcedir, "examples/rm.go"),
+	}
 
 	completionTests = []completionTest{
 		{
@@ -224,6 +232,20 @@ func init() {
 			// Flag long filename
 			[]string{"rm", "--filename", path.Join(completionTestSourcedir, "completion")},
 			completionTestFilename,
+			false,
+		},
+
+		{
+			// Flag filepath file
+			[]string{"rm", "-d", path.Join(completionTestSourcedir, "completion")},
+			completionTestFilename,
+			false,
+		},
+
+		{
+			// Flag filepath dir
+			[]string{"rm", "-d", path.Join(completionTestSourcedir, "examples")},
+			completionTestFilepath,
 			false,
 		},
 


### PR DESCRIPTION
I have some cases where this was the behaviour I wanted; obviously users can implement this themselves but it seems pretty generally useful (probably as much so as Filename?).