### PR TITLE
should use os.LookupEnv instead of syscall.Getenv

### DIFF
--- a/option.go
+++ b/option.go
@@ -3,9 +3,9 @@ package flags
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
-	"syscall"
 	"unicode/utf8"
 )
 
@@ -261,9 +261,7 @@ func (option *Option) clearDefault() {
 	usedDefault := option.Default
 
 	if envKey := option.EnvDefaultKey; envKey != "" {
-		// os.Getenv() makes no distinction between undefined and
-		// empty values, so we use syscall.Getenv()
-		if value, ok := syscall.Getenv(envKey); ok {
+		if value, ok := os.LookupEnv(envKey); ok {
 			if option.EnvDefaultDelim != "" {
 				usedDefault = strings.Split(value,
 					option.EnvDefaultDelim)


### PR DESCRIPTION
`os.LookupEnv` is added on go 1.5.
So it has not to use `syscall.Getenv` to distinction between undefined and empty values.
see: https://golang.org/doc/go1.5