### PR TITLE
Adding WroteHelp() helper

### DIFF
--- a/help.go
+++ b/help.go
@@ -489,3 +489,23 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 
 	wr.Flush()
 }
+
+// WroteHelp is a helper to test the error from ParseArgs() to
+// determine if the help message was written. It is safe to
+// call without first checking that error is nil.
+func WroteHelp(err error) bool {
+	if err == nil { // No error
+		return false
+	}
+
+	flagError, ok := err.(*Error)
+	if !ok { // Not a go-flag error
+		return false
+	}
+
+	if flagError.Type != ErrHelp { // Did not print the help message
+		return false
+	}
+
+	return true
+}

--- a/help_test.go
+++ b/help_test.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -534,5 +535,27 @@ func TestHelpDefaultMask(t *testing.T) {
 		if strings.Index(h.String(), test.present) < 0 {
 			t.Errorf("Not present %q\n%s", test.present, h.String())
 		}
+	}
+}
+
+func TestWroteHelp(t *testing.T) {
+	type testInfo struct {
+		value  error
+		isHelp bool
+	}
+	tests := map[string]testInfo{
+		"No error":    testInfo{value: nil, isHelp: false},
+		"Plain error": testInfo{value: errors.New("an error"), isHelp: false},
+		"ErrUnknown":  testInfo{value: newError(ErrUnknown, "an error"), isHelp: false},
+		"ErrHelp":     testInfo{value: newError(ErrHelp, "an error"), isHelp: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := WroteHelp(test.value)
+			if test.isHelp != res {
+				t.Errorf("Expected %t, got %t", test.isHelp, res)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adding a helper function to simplify the `Parse*()` caller determining if the help text was written or not.

Usage would look like:

```go
...
_, err := flags.Parse(opts)
if flags.WroteHelp(err) {
    os.Exit(0)
}
if err != nil {
    ...
}
...
```

Test output:
```
$ go test -v -run TestWroteHelp
=== RUN   TestWroteHelp
=== RUN   TestWroteHelp/No_error
=== RUN   TestWroteHelp/Plain_error
=== RUN   TestWroteHelp/ErrUnknown
=== RUN   TestWroteHelp/ErrHelp
--- PASS: TestWroteHelp (0.00s)
    --- PASS: TestWroteHelp/No_error (0.00s)
    --- PASS: TestWroteHelp/Plain_error (0.00s)
    --- PASS: TestWroteHelp/ErrUnknown (0.00s)
    --- PASS: TestWroteHelp/ErrHelp (0.00s)
PASS
ok  	github.com/jessevdk/go-flags	0.002s
```