### PR TITLE
Fix termsize in wasm arch

### DIFF
--- a/termsize.go
+++ b/termsize.go
@@ -1,4 +1,4 @@
-// +build !windows,!plan9,!solaris,!appengine
+// +build !windows,!plan9,!solaris,!appengine,!wasm
 
 package flags
 

--- a/termsize_nosysioctl.go
+++ b/termsize_nosysioctl.go
@@ -1,4 +1,4 @@
-// +build windows plan9 solaris appengine
+// +build windows plan9 solaris appengine wasm
 
 package flags
 


### PR DESCRIPTION
This enables usage of go-flags in the wasm architecture.