### PR TITLE
This fixes issue #269 and #270

### DIFF
--- a/command.go
+++ b/command.go
@@ -438,7 +438,7 @@ func (c *Command) match(name string) bool {
 	return false
 }
 
-func (c *Command) hasCliOptions() bool {
+func (c *Command) hasHelpOptions() bool {
 	ret := false
 
 	c.eachGroup(func(g *Group) {
@@ -447,7 +447,7 @@ func (c *Command) hasCliOptions() bool {
 		}
 
 		for _, opt := range g.options {
-			if opt.canCli() {
+			if opt.showInHelp() {
 				ret = true
 			}
 		}

--- a/help.go
+++ b/help.go
@@ -79,7 +79,7 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 		}
 
 		for _, info := range grp.options {
-			if !info.canCli() {
+			if !info.showInHelp() {
 				continue
 			}
 
@@ -305,7 +305,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 				}
 			} else if us, ok := allcmd.data.(Usage); ok {
 				usage = us.Usage()
-			} else if allcmd.hasCliOptions() {
+			} else if allcmd.hasHelpOptions() {
 				usage = fmt.Sprintf("[%s-OPTIONS]", allcmd.Name)
 			}
 
@@ -393,7 +393,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			}
 
 			for _, info := range grp.options {
-				if !info.canCli() {
+				if !info.showInHelp() {
 					continue
 				}
 

--- a/help.go
+++ b/help.go
@@ -393,7 +393,7 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 			}
 
 			for _, info := range grp.options {
-				if !info.canCli() || info.Hidden {
+				if !info.canCli() {
 					continue
 				}
 

--- a/help_test.go
+++ b/help_test.go
@@ -26,6 +26,8 @@ type helpOptions struct {
 	OptionWithChoices string            `long:"opt-with-choices" value-name:"choice" choice:"dog" choice:"cat" description:"Option with choices"`
 	Hidden            string            `long:"hidden" description:"Hidden option" hidden:"yes"`
 
+	HiddenOptionWithVeryLongName bool `long:"this-hidden-option-has-a-ridiculously-long-name" hidden:"yes"`
+
 	OnlyIni string `ini-name:"only-ini" description:"Option only available in ini"`
 
 	Other struct {
@@ -46,6 +48,10 @@ type helpOptions struct {
 			Opt string `long:"opt" description:"This is a subsubgroup option"`
 		} `group:"Subsubgroup" namespace:"sap"`
 	} `group:"Subgroup" namespace:"sip"`
+
+	Bommand struct {
+		Hidden bool `long:"hidden" description:"A hidden option" hidden:"yes"`
+	} `command:"bommand" description:"A command with only hidden options"`
 
 	Command struct {
 		ExtraVerbose []bool `long:"extra-verbose" description:"Use for extra verbosity"`
@@ -88,7 +94,7 @@ func TestHelp(t *testing.T) {
 
 		if runtime.GOOS == "windows" {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <command>
+  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command>
 
 Application Options:
   /v, /verbose                              Show verbose debug information
@@ -131,11 +137,12 @@ Arguments:
   num:                                      A number
 
 Available commands:
+  bommand  A command with only hidden options
   command  A command (aliases: cm, cmd)
 `
 		} else {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <command>
+  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command>
 
 Application Options:
   -v, --verbose                             Show verbose debug information
@@ -177,6 +184,7 @@ Arguments:
   num:                                      A number
 
 Available commands:
+  bommand  A command with only hidden options
   command  A command (aliases: cm, cmd)
 `
 		}
@@ -196,7 +204,9 @@ func TestMan(t *testing.T) {
 	p.LongDescription = "This is a somewhat `longer' description of what this does"
 	p.AddGroup("Application Options", "The application options", &opts)
 
-	p.Commands()[0].LongDescription = "Longer `command' description"
+	for _, cmd := range p.Commands() {
+		cmd.LongDescription = fmt.Sprintf("Longer `%s' description", cmd.Name)
+	}
 
 	var buf bytes.Buffer
 	p.WriteManPage(&buf)
@@ -274,6 +284,10 @@ Not hidden inside group
 \fB\fB\-\-sip.sap.opt\fR\fP
 This is a subsubgroup option
 .SH COMMANDS
+.SS bommand
+A command with only hidden options
+
+Longer \fBbommand\fP description
 .SS command
 A command
 

--- a/man.go
+++ b/man.go
@@ -54,7 +54,7 @@ func writeManPageOptions(wr io.Writer, grp *Group) {
 		}
 
 		for _, opt := range group.options {
-			if !opt.canCli() || opt.Hidden {
+			if !opt.canCli() {
 				continue
 			}
 

--- a/man.go
+++ b/man.go
@@ -54,7 +54,7 @@ func writeManPageOptions(wr io.Writer, grp *Group) {
 		}
 
 		for _, opt := range group.options {
-			if !opt.canCli() {
+			if !opt.showInHelp() {
 				continue
 			}
 
@@ -148,12 +148,12 @@ func writeManPageCommand(wr io.Writer, name string, root *Command, command *Comm
 	var usage string
 	if us, ok := command.data.(Usage); ok {
 		usage = us.Usage()
-	} else if command.hasCliOptions() {
+	} else if command.hasHelpOptions() {
 		usage = fmt.Sprintf("[%s-OPTIONS]", command.Name)
 	}
 
 	var pre string
-	if root.hasCliOptions() {
+	if root.hasHelpOptions() {
 		pre = fmt.Sprintf("%s [OPTIONS] %s", root.Name, command.Name)
 	} else {
 		pre = fmt.Sprintf("%s %s", root.Name, command.Name)

--- a/option.go
+++ b/option.go
@@ -280,7 +280,7 @@ func (option *Option) set(value *string) error {
 	return convert("", option.value, option.tag)
 }
 
-func (option *Option) canCli() bool {
+func (option *Option) showInHelp() bool {
 	return !option.Hidden && (option.ShortName != 0 || len(option.LongName) != 0)
 }
 

--- a/option.go
+++ b/option.go
@@ -281,7 +281,7 @@ func (option *Option) set(value *string) error {
 }
 
 func (option *Option) canCli() bool {
-	return option.ShortName != 0 || len(option.LongName) != 0
+	return !option.Hidden && (option.ShortName != 0 || len(option.LongName) != 0)
 }
 
 func (option *Option) canArgument() bool {


### PR DESCRIPTION
It changes the definition of `(*Option).canCli()` to also check
whether an option is hidden.

There's still some work to be done in this area as a group with no
non-hidden options will also not render right, but I'll get to that
later.