### PR TITLE
Fix issue #273

### DIFF
--- a/group.go
+++ b/group.go
@@ -168,6 +168,18 @@ func (g *Group) optionByName(name string, namematch func(*Option, string) bool) 
 	return retopt
 }
 
+func (g *Group) showInHelp() bool {
+	if g.Hidden {
+		return false
+	}
+	for _, opt := range g.options {
+		if opt.showInHelp() {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *Group) eachGroup(f func(*Group)) {
 	f(g)
 

--- a/help_test.go
+++ b/help_test.go
@@ -40,6 +40,10 @@ type helpOptions struct {
 		InsideHiddenGroup string `long:"inside-hidden-group" description:"Inside hidden group"`
 	} `group:"Hidden group" hidden:"yes"`
 
+	GroupWithOnlyHiddenOptions struct {
+		SecretFlag bool `long:"secret" description:"Hidden flag in a non-hidden group" hidden:"yes"`
+	} `group:"Non-hidden group with only hidden options"`
+
 	Group struct {
 		Opt                  string `long:"opt" description:"This is a subgroup option"`
 		HiddenInsideGroup    string `long:"hidden-inside-group" description:"Hidden inside group" hidden:"yes"`

--- a/man.go
+++ b/man.go
@@ -38,7 +38,7 @@ func formatForMan(wr io.Writer, s string) {
 
 func writeManPageOptions(wr io.Writer, grp *Group) {
 	grp.eachGroup(func(group *Group) {
-		if group.Hidden || len(group.options) == 0 {
+		if !group.showInHelp() {
 			return
 		}
 


### PR DESCRIPTION
Without this change, a non-hidden group with only hidden options will
still appear in the generated manpage. This fixes that.