### PR TITLE
Clarify that an error was expected but did not occur

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -103,7 +103,7 @@ func assertParseSuccess(t *testing.T, data interface{}, args ...string) []string
 
 func assertError(t *testing.T, err error, typ ErrorType, msg string) {
 	if err == nil {
-		assertFatalf(t, "Expected error: %s", msg)
+		assertFatalf(t, "Expected error: \"%s\", but no error occurred", msg)
 		return
 	}
 


### PR DESCRIPTION
This change made it easier for us to determine what test was failing and why.

Signed-off-by: Anand Gaitonde <agaitonde@pivotal.io>