### PR TITLE
fix #278

### DIFF
--- a/help.go
+++ b/help.go
@@ -72,6 +72,9 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 	var prevcmd *Command
 
 	p.eachActiveGroup(func(c *Command, grp *Group) {
+		if !grp.showInHelp() {
+			return
+		}
 		if c != prevcmd {
 			for _, arg := range c.args {
 				ret.updateLen(arg.Name, c != p.Command)

--- a/help_test.go
+++ b/help_test.go
@@ -38,6 +38,7 @@ type helpOptions struct {
 
 	HiddenGroup struct {
 		InsideHiddenGroup string `long:"inside-hidden-group" description:"Inside hidden group"`
+		Padder            bool   `long:"this-option-in-a-hidden-group-has-a-ridiculously-long-name"`
 	} `group:"Hidden group" hidden:"yes"`
 
 	GroupWithOnlyHiddenOptions struct {


### PR DESCRIPTION
WriteHelp wasn't checking a group was shown in the help output before
looping over it to check alignment. This fixes that, and thus #278.