### PR TITLE
Do not skip groups that are commands when working out alignment

### DIFF
--- a/help.go
+++ b/help.go
@@ -69,10 +69,16 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 		ret.terminalColumns = 80
 	}
 
+	isCmd := map[*Group]bool{}
+	p.eachCommand(func(cmd *Command) {
+		// TODO: have (*Command).showInHelp() to consider hidden vs active
+		isCmd[cmd.Group] = true
+	}, true)
+
 	var prevcmd *Command
 
 	p.eachActiveGroup(func(c *Command, grp *Group) {
-		if !grp.showInHelp() {
+		if !(isCmd[grp] || grp.showInHelp()) {
 			return
 		}
 		if c != prevcmd {

--- a/help_test.go
+++ b/help_test.go
@@ -563,10 +563,10 @@ func TestWroteHelp(t *testing.T) {
 		isHelp bool
 	}
 	tests := map[string]testInfo{
-		"No error":    testInfo{value: nil, isHelp: false},
-		"Plain error": testInfo{value: errors.New("an error"), isHelp: false},
-		"ErrUnknown":  testInfo{value: newError(ErrUnknown, "an error"), isHelp: false},
-		"ErrHelp":     testInfo{value: newError(ErrHelp, "an error"), isHelp: true},
+		"No error":    {value: nil, isHelp: false},
+		"Plain error": {value: errors.New("an error"), isHelp: false},
+		"ErrUnknown":  {value: newError(ErrUnknown, "an error"), isHelp: false},
+		"ErrHelp":     {value: newError(ErrHelp, "an error"), isHelp: true},
 	}
 
 	for name, test := range tests {
@@ -577,4 +577,16 @@ func TestWroteHelp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOnlyPositional(t *testing.T) {
+	type options struct {
+		Positional struct {
+			Bar string `description:"bar"`
+		} `positional-args:"yes"`
+	}
+
+	var buf bytes.Buffer
+	NewParser(&options{}, 0).WriteHelp(&buf)
+	// just checking for no panic, at this point
 }


### PR DESCRIPTION
Without this change, groups that are commands but that don't satisfy
(*Group).showInHelp() would be skipped when working out the alignment,
which would result in negative lengths when trying to process a group
with only positional options.

This fixes #280.
