### PR TITLE
Fix writing INI and man pages for subcommands

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -329,7 +329,7 @@ This is a parent command option
 .SS parent sub
 A sub command
 
-\fBUsage\fP: parent [OPTIONS] sub [sub-OPTIONS]
+\fBUsage\fP: TestMan [OPTIONS] parent [parent-OPTIONS] sub [sub-OPTIONS]
 .TP
 .TP
 \fB\fB\-\-opt\fR\fP

--- a/help_test.go
+++ b/help_test.go
@@ -67,6 +67,13 @@ type helpOptions struct {
 		ExtraVerbose []bool `long:"extra-verbose" description:"Use for extra verbosity"`
 	} `command:"hidden-command" description:"A hidden command" hidden:"yes"`
 
+	ParentCommand struct {
+		Opt        string `long:"opt" description:"This is a parent command option"`
+		SubCommand struct {
+			Opt string `long:"opt" description:"This is a sub command option"`
+		} `command:"sub" description:"A sub command"`
+	} `command:"parent" description:"A parent command"`
+
 	Args struct {
 		Filename     string  `positional-arg-name:"filename" description:"A filename with a long description to trigger line wrapping"`
 		Number       int     `positional-arg-name:"num" description:"A number"`
@@ -100,7 +107,7 @@ func TestHelp(t *testing.T) {
 
 		if runtime.GOOS == "windows" {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command>
+  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command | parent>
 
 Application Options:
   /v, /verbose                              Show verbose debug information
@@ -145,10 +152,11 @@ Arguments:
 Available commands:
   bommand  A command with only hidden options
   command  A command (aliases: cm, cmd)
+  parent   A command with a sub command
 `
 		} else {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command>
+  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command | parent>
 
 Application Options:
   -v, --verbose                             Show verbose debug information
@@ -192,6 +200,7 @@ Arguments:
 Available commands:
   bommand  A command with only hidden options
   command  A command (aliases: cm, cmd)
+  parent   A parent command
 `
 		}
 
@@ -307,6 +316,24 @@ Longer \fBcommand\fP description
 .TP
 \fB\fB\-\-extra-verbose\fR\fP
 Use for extra verbosity
+.SS parent
+A parent command
+
+Longer \fBparent\fP description
+
+\fBUsage\fP: TestMan [OPTIONS] parent [parent-OPTIONS]
+.TP
+.TP
+\fB\fB\-\-opt\fR\fP
+This is a parent command option
+.SS parent sub
+A sub command
+
+\fBUsage\fP: parent [OPTIONS] sub [sub-OPTIONS]
+.TP
+.TP
+\fB\fB\-\-opt\fR\fP
+This is a sub command option
 `, tt.Format("2 January 2006"), envDefaultName)
 
 	assertDiff(t, got, expected, "man page")

--- a/ini.go
+++ b/ini.go
@@ -325,19 +325,19 @@ func writeCommandIni(command *Command, namespace string, writer io.Writer, optio
 	})
 
 	for _, c := range command.commands {
-		var nns string
+		var fqn string
 
 		if c.Hidden {
 			continue
 		}
 
 		if len(namespace) != 0 {
-			nns = c.Name + "." + nns
+			fqn = namespace + "." + c.Name
 		} else {
-			nns = c.Name
+			fqn = c.Name
 		}
 
-		writeCommandIni(c, nns, writer, options)
+		writeCommandIni(c, fqn, writer, options)
 	}
 }
 

--- a/ini_test.go
+++ b/ini_test.go
@@ -104,6 +104,14 @@ Opt =
 ; Use for extra verbosity
 ; ExtraVerbose =
 
+[parent]
+; This is a parent command option
+Opt =
+
+[parent.sub]
+; This is a sub command option
+Opt =
+
 `,
 		},
 		{
@@ -167,6 +175,14 @@ EnvDefault2 = env-def
 ; Use for extra verbosity
 ; ExtraVerbose =
 
+[parent]
+; This is a parent command option
+; Opt =
+
+[parent.sub]
+; This is a sub command option
+; Opt =
+
 `,
 		},
 		{
@@ -227,6 +243,38 @@ EnvDefault2 = env-def
 [command]
 ; Use for extra verbosity
 ; ExtraVerbose =
+
+[parent]
+; This is a parent command option
+; Opt =
+
+[parent.sub]
+; This is a sub command option
+; Opt =
+
+`,
+		},
+		{
+			[]string{"-vv", "filename", "0", "3.14", "parent", "--opt=p", "sub", "--opt=s"},
+			IniDefault,
+			`[Application Options]
+; Show verbose debug information
+verbose = true
+verbose = true
+
+; Test env-default1 value
+EnvDefault1 = env-def
+
+; Test env-default2 value
+EnvDefault2 = env-def
+
+[parent]
+; This is a parent command option
+Opt = p
+
+[parent.sub]
+; This is a sub command option
+Opt = s
 
 `,
 		},


### PR DESCRIPTION
This PR addresses two issues pertaining to subcommands: writing the INI and writing the man pages.

The work is split across two commits. The first commit addresses an issue where INI sections for subcommands were written as `[sub.]` instead of `[parent.sub]`. The second commit addresses an issue with usage text in man pages where commands only included the usage text of their immediate parent instead of a complete usage starting from the root.