### PR TITLE
Added option "depends"

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -346,3 +346,16 @@ func unquoteIfPossible(s string) (string, error) {
 
 	return strconv.Unquote(s)
 }
+
+func convertOptionToLog(option *Option) string {
+
+	if 0 != len(string(option.ShortName)) && (0 != len(option.LongName)) {
+		return fmt.Sprintf("-%s (--%s), ", string(option.ShortName), option.LongName)
+	}
+
+	if 0 != len(option.LongName) {
+		return fmt.Sprintf("-%s, ", option.LongName)
+	}
+
+	return fmt.Sprintf("-%s, ", string(option.ShortName))
+}

--- a/depends.go
+++ b/depends.go
@@ -1,12 +1,14 @@
 package flags
+
 import "unicode/utf8"
+
 func gatherOptions(group *Group, options *[]*Option) {
 	for _, opt := range group.options {
 		*options = append(*options, opt)
 	}
 
 	for _, child := range group.groups {
-		gatherOptions(child, options )
+		gatherOptions(child, options)
 	}
 }
 
@@ -18,7 +20,7 @@ func addDependsOption(option *Option, depends *Option) {
 	option.DependsOptions = append(option.DependsOptions, depends)
 }
 func verifyDependencies(p *Parser) error {
-	options := make([]*Option, 0 )
+	options := make([]*Option, 0)
 	gatherOptions(p.groups[0], &options)
 
 	for _, option := range options {

--- a/depends.go
+++ b/depends.go
@@ -1,0 +1,49 @@
+package flags
+import "unicode/utf8"
+func gatherOptions(group *Group, options *[]*Option) {
+	for _, opt := range group.options {
+		*options = append(*options, opt)
+	}
+
+	for _, child := range group.groups {
+		gatherOptions(child, options )
+	}
+}
+
+func verifyDependencies(p *Parser) *Error {
+	options := make([]*Option, 0 )
+	gatherOptions(p.groups[0], &options)
+
+	for _, option := range options {
+		// For each option, check dependencies
+		for _, dependency := range option.Depends {
+			// found dependent option, traverse options and the field it points to
+			found := false
+			for _, field := range options {
+				// Check for short name, specified name is short
+				if 1 == len(dependency) {
+					opt, _ := utf8.DecodeRuneInString(dependency)
+					if field.ShortName == opt {
+						found = true
+						option.DependsOptions = append(option.DependsOptions, field)
+						break
+					}
+					// We didnt find it within short names, check for long names
+				}
+
+				if field.LongName == dependency {
+					found = true
+					option.DependsOptions = append(option.DependsOptions, field)
+					break
+				}
+			}
+
+			if !found {
+				// We didnt find the field, error in configuration
+				return newErrorf(ErrInvalidTag, "flag '%s' dependency '%s' is pointing to non existent flag", convertOptionToLog(option), dependency)
+			}
+		}
+	}
+
+	return nil
+}

--- a/depends.go
+++ b/depends.go
@@ -10,7 +10,14 @@ func gatherOptions(group *Group, options *[]*Option) {
 	}
 }
 
-func verifyDependencies(p *Parser) *Error {
+func addDependsOption(option *Option, depends *Option) {
+	if nil == option.DependsOptions {
+		option.DependsOptions = make([]*Option, 0)
+	}
+
+	option.DependsOptions = append(option.DependsOptions, depends)
+}
+func verifyDependencies(p *Parser) error {
 	options := make([]*Option, 0 )
 	gatherOptions(p.groups[0], &options)
 
@@ -25,7 +32,7 @@ func verifyDependencies(p *Parser) *Error {
 					opt, _ := utf8.DecodeRuneInString(dependency)
 					if field.ShortName == opt {
 						found = true
-						option.DependsOptions = append(option.DependsOptions, field)
+						addDependsOption(option, field)
 						break
 					}
 					// We didnt find it within short names, check for long names
@@ -33,7 +40,7 @@ func verifyDependencies(p *Parser) *Error {
 
 				if field.LongName == dependency {
 					found = true
-					option.DependsOptions = append(option.DependsOptions, field)
+					addDependsOption(option, field)
 					break
 				}
 			}

--- a/error.go
+++ b/error.go
@@ -58,6 +58,9 @@ const (
 
 	// ErrInvalidTag indicates an invalid tag or invalid use of an existing tag
 	ErrInvalidTag
+
+	// ErrDependent indicates that dependent parameter was not specified
+	ErrDependent
 )
 
 func (e ErrorType) String() string {
@@ -92,7 +95,10 @@ func (e ErrorType) String() string {
 		return "invalid choice"
 	case ErrInvalidTag:
 		return "invalid tag"
+	case ErrDependent:
+		return "dependent parameter not specified"
 	}
+
 
 	return "unrecognized error type"
 }

--- a/error.go
+++ b/error.go
@@ -58,6 +58,9 @@ const (
 
 	// ErrInvalidTag indicates an invalid tag or invalid use of an existing tag
 	ErrInvalidTag
+
+	// ErrDependent indicates that dependent parameter was not specified
+	ErrDependent
 )
 
 func (e ErrorType) String() string {
@@ -92,6 +95,8 @@ func (e ErrorType) String() string {
 		return "invalid choice"
 	case ErrInvalidTag:
 		return "invalid tag"
+	case ErrDependent:
+		return "dependent parameter not specified"
 	}
 
 	return "unrecognized error type"

--- a/error.go
+++ b/error.go
@@ -58,9 +58,6 @@ const (
 
 	// ErrInvalidTag indicates an invalid tag or invalid use of an existing tag
 	ErrInvalidTag
-
-	// ErrDependent indicates that dependent parameter was not specified
-	ErrDependent
 )
 
 func (e ErrorType) String() string {
@@ -95,10 +92,7 @@ func (e ErrorType) String() string {
 		return "invalid choice"
 	case ErrInvalidTag:
 		return "invalid tag"
-	case ErrDependent:
-		return "dependent parameter not specified"
 	}
-
 
 	return "unrecognized error type"
 }

--- a/group.go
+++ b/group.go
@@ -311,39 +311,6 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		g.options = append(g.options, option)
 	}
 
-	// Find dependencies, traverse options
-	for _, option := range g.options {
-		// For each option, check dependencies
-		for _, dependency := range option.Depends {
-			// found dependent option, traverse options and the field it points to
-			found := false
-			for _, field := range g.options {
-				// Check for short name, specified name is short
-				if 1 == len(dependency) {
-					opt, _ := utf8.DecodeRuneInString(dependency)
-					if field.ShortName == opt {
-						found = true
-						option.DependsOptions = append(option.DependsOptions, field)
-						break
-					}
-					// We didnt find it within short names, check for long names
-				}
-
-				if field.LongName == dependency {
-					found = true
-					option.DependsOptions = append(option.DependsOptions, field)
-					break
-				}
-			}
-
-			if !found {
-				// We didnt find the field, error in configuration
-				return newErrorf(ErrInvalidTag,
-					"flag '%s' dependency '%s' is pointing to non existent flag", convertOptionToLog(option), dependency)
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/group.go
+++ b/group.go
@@ -277,7 +277,6 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		required := !isStringFalsy(mtag.Get("required"))
 		choices := mtag.GetMany("choice")
 		hidden := !isStringFalsy(mtag.Get("hidden"))
-		depends := mtag.GetMany("depends")
 
 		option := &Option{
 			Description:      description,
@@ -293,7 +292,6 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			DefaultMask:      defaultMask,
 			Choices:          choices,
 			Hidden:           hidden,
-			Depends:		  depends,
 
 			group: g,
 
@@ -309,31 +307,6 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		}
 
 		g.options = append(g.options, option)
-	}
-
-	// Find dependencies, traverse options
-	for _, option := range g.options {
-		// For each option, check dependencies
-		for _, dependency := range option.Depends {
-			// found dependent option, traverse options and the field it points to
-			for _, field := range g.options {
-				// Check for short name, specified name is short
-				if 1 == len(dependency) {
-					opt, _ := utf8.DecodeRuneInString(dependency)
-					if field.ShortName == opt {
-						option.DependsOptions = append(option.DependsOptions, field);
-						continue
-					}
-					// We didnt find it within short names, check for long names
-				}
-
-				if field.LongName == dependency {
-					option.DependsOptions = append(option.DependsOptions, field);
-				}
-
-				// We didnt find the field, error in configuration
-			}
-		}
 	}
 
 	return nil

--- a/group.go
+++ b/group.go
@@ -277,6 +277,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		required := !isStringFalsy(mtag.Get("required"))
 		choices := mtag.GetMany("choice")
 		hidden := !isStringFalsy(mtag.Get("hidden"))
+		depends := mtag.GetMany("depends")
 
 		option := &Option{
 			Description:      description,
@@ -292,6 +293,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			DefaultMask:      defaultMask,
 			Choices:          choices,
 			Hidden:           hidden,
+			Depends:		  depends,
 
 			group: g,
 
@@ -307,6 +309,31 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		}
 
 		g.options = append(g.options, option)
+	}
+
+	// Find dependencies, traverse options
+	for _, option := range g.options {
+		// For each option, check dependencies
+		for _, dependency := range option.Depends {
+			// found dependent option, traverse options and the field it points to
+			for _, field := range g.options {
+				// Check for short name, specified name is short
+				if 1 == len(dependency) {
+					opt, _ := utf8.DecodeRuneInString(dependency)
+					if field.ShortName == opt {
+						option.DependsOptions = append(option.DependsOptions, field);
+						continue
+					}
+					// We didnt find it within short names, check for long names
+				}
+
+				if field.LongName == dependency {
+					option.DependsOptions = append(option.DependsOptions, field);
+				}
+
+				// We didnt find the field, error in configuration
+			}
+		}
 	}
 
 	return nil

--- a/option.go
+++ b/option.go
@@ -68,6 +68,10 @@ type Option struct {
 	// If true, the option is not displayed in the help or man page
 	Hidden bool
 
+	// Current value depends on following values.
+	Depends []string
+	DependsOptions []*Option
+
 	// The group which the option belongs to
 	group *Group
 

--- a/option.go
+++ b/option.go
@@ -68,6 +68,10 @@ type Option struct {
 	// If true, the option is not displayed in the help or man page
 	Hidden bool
 
+	// Current value depends on following values.
+	Depends        []string
+	DependsOptions []*Option
+
 	// The group which the option belongs to
 	group *Group
 

--- a/option.go
+++ b/option.go
@@ -68,10 +68,6 @@ type Option struct {
 	// If true, the option is not displayed in the help or man page
 	Hidden bool
 
-	// Current value depends on following values.
-	Depends []string
-	DependsOptions []*Option
-
 	// The group which the option belongs to
 	group *Group
 

--- a/parser.go
+++ b/parser.go
@@ -318,8 +318,6 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 		})
 
 		s.checkRequired(p)
-
-		s.checkDependent(p)
 	}
 
 	var reterr error
@@ -374,55 +372,6 @@ func (p *parseState) peek() string {
 	}
 
 	return p.args[0]
-}
-
-func (p *parseState) optionToString (option *Option) string {
-
-	if 0 != len(string(option.ShortName)) && (0 != len(option.LongName)){
-		return fmt.Sprintf("-%s (--%s), ", string(option.ShortName), option.LongName )
-	}
-
-	if 0 != len(option.LongName) {
-		return fmt.Sprintf("-%s, ", option.LongName )
-	}
-
-	return fmt.Sprintf("-%s, ", string(option.ShortName) )
-}
-
-func (p *parseState) checkDependent(parser *Parser) error {
-	c := parser.Command
-
-	missing := false
-
-	for c != nil {
-		c.eachGroup(func(g *Group) {
-			for _, option := range g.options {
-				if option.isSet {
-					required := ""
-					for _, dependent := range option.DependsOptions {
-						if !dependent.isSet {
-							missing = true
-							required += fmt.Sprintf("%s, ", p.optionToString(dependent) )
-						}
-					}
-
-					if 0 != len(required) {
-						required = strings.Trim(required, ", ")
-
-						fmt.Printf("argument %s specified but missing dependent argument(s): %s\n", p.optionToString(option), required)
-					}
-				}
-			}
-		})
-
-		c = c.Active
-	}
-
-	if missing {
-		p.err = newError(ErrDependent, "the dependent argument(s) not provided")
-	}
-
-	return p.err
 }
 
 func (p *parseState) checkRequired(parser *Parser) error {

--- a/parser.go
+++ b/parser.go
@@ -165,6 +165,11 @@ func NewParser(data interface{}, options Options) *Parser {
 		p.internalError = err
 	}
 
+	// if there was no error, check for dependent options
+	if nil == p.internalError {
+		p.internalError = verifyDependencies(p)
+	}
+
 	return p
 }
 

--- a/parser.go
+++ b/parser.go
@@ -387,7 +387,7 @@ func (p *parseState) checkDependent(parser *Parser) error {
 				if option.isSet && !option.isSetDefault {
 					required := ""
 					for _, dependent := range option.DependsOptions {
-						if !dependent.isSet && !option.isSetDefault{
+						if !dependent.isSet && !option.isSetDefault {
 							missing = true
 							required += fmt.Sprintf("%s, ", convertOptionToLog(dependent))
 						}

--- a/parser.go
+++ b/parser.go
@@ -318,6 +318,8 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 		})
 
 		s.checkRequired(p)
+
+		s.checkDependent(p)
 	}
 
 	var reterr error
@@ -372,6 +374,55 @@ func (p *parseState) peek() string {
 	}
 
 	return p.args[0]
+}
+
+func (p *parseState) optionToString (option *Option) string {
+
+	if 0 != len(string(option.ShortName)) && (0 != len(option.LongName)){
+		return fmt.Sprintf("-%s (--%s), ", string(option.ShortName), option.LongName )
+	}
+
+	if 0 != len(option.LongName) {
+		return fmt.Sprintf("-%s, ", option.LongName )
+	}
+
+	return fmt.Sprintf("-%s, ", string(option.ShortName) )
+}
+
+func (p *parseState) checkDependent(parser *Parser) error {
+	c := parser.Command
+
+	missing := false
+
+	for c != nil {
+		c.eachGroup(func(g *Group) {
+			for _, option := range g.options {
+				if option.isSet {
+					required := ""
+					for _, dependent := range option.DependsOptions {
+						if !dependent.isSet {
+							missing = true
+							required += fmt.Sprintf("%s, ", p.optionToString(dependent) )
+						}
+					}
+
+					if 0 != len(required) {
+						required = strings.Trim(required, ", ")
+
+						fmt.Printf("argument %s specified but missing dependent argument(s): %s\n", p.optionToString(option), required)
+					}
+				}
+			}
+		})
+
+		c = c.Active
+	}
+
+	if missing {
+		p.err = newError(ErrDependent, "the dependent argument(s) not provided")
+	}
+
+	return p.err
 }
 
 func (p *parseState) checkRequired(parser *Parser) error {


### PR DESCRIPTION
By specifying `depends:x` the option x is required for this parameter:

Param1      string `short:"a" long:"param1" depends:"privatekey"`
Param2 string `short:"b" long:"param2" depends:"param1"`
Param3 string `short:"c" long:"param3" default:"" depends:"a"`

This would mean, that -b and -c require -a parameter, while -c doesnt require -b and vice versa.


