### PR TITLE
 Add ability to programmatically add options to a group 

### DIFF
--- a/group.go
+++ b/group.go
@@ -74,8 +74,8 @@ func (g *Group) AddGroup(shortDescription string, longDescription string, data i
 }
 
 // AddOption adds a new option to this group.
-func (g *Group) AddOption(option *Option, value reflect.Value) {
-	option.value = value
+func (g *Group) AddOption(option *Option, data interface{}) {
+	option.value = reflect.ValueOf(data)
 	option.group = g
 	g.options = append(g.options, option)
 }

--- a/group.go
+++ b/group.go
@@ -73,6 +73,13 @@ func (g *Group) AddGroup(shortDescription string, longDescription string, data i
 	return group, nil
 }
 
+// AddOption adds a new option to this group.
+func (g *Group) AddOption(option *Option, value reflect.Value) {
+	option.value = value
+	option.group = g
+	g.options = append(g.options, option)
+}
+
 // Groups returns the list of groups embedded in this group.
 func (g *Group) Groups() []*Group {
 	return g.groups

--- a/group_test.go
+++ b/group_test.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -262,7 +261,7 @@ func TestAddOptionNonOptional(t *testing.T) {
 	p := NewParser(&opts, Default)
 	p.AddOption(&Option{
 		LongName: "test",
-	}, reflect.ValueOf(&opts.Test))
+	}, &opts.Test)
 	_, err := p.ParseArgs([]string{"--test"})
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)

--- a/group_test.go
+++ b/group_test.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -251,5 +252,21 @@ func TestFindOptionByShortFlagInSubGroup(t *testing.T) {
 
 	if opt.ShortName != 't' {
 		t.Errorf("Expected 't', but got %v", opt.ShortName)
+	}
+}
+
+func TestAddOptionNonOptional(t *testing.T) {
+	var opts struct {
+		Test bool
+	}
+	p := NewParser(&opts, Default)
+	p.AddOption(&Option{
+		LongName: "test",
+	}, reflect.ValueOf(&opts.Test))
+	_, err := p.ParseArgs([]string{"--test"})
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if !opts.Test {
+		t.Errorf("option not set")
 	}
 }


### PR DESCRIPTION
One can add commands & groups programmatically, but not options. We've found this useful to be able to dynamically build up subcommands (mostly for completion, but could do more with it too).