### PR TITLE
Make option.set public

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -572,7 +572,7 @@ func (i *IniParser) parse(ini *ini) error {
 				}
 			}
 
-			if err := opt.set(pval); err != nil {
+			if err := opt.Set(pval); err != nil {
 				return &IniError{
 					Message:    err.Error(),
 					File:       ini.File,

--- a/option.go
+++ b/option.go
@@ -238,7 +238,7 @@ func (option *Option) IsSetDefault() bool {
 // Set the value of an option to the specified value. An error will be returned
 // if the specified value could not be converted to the corresponding option
 // value type.
-func (option *Option) set(value *string) error {
+func (option *Option) Set(value *string) error {
 	kind := option.value.Type().Kind()
 
 	if (kind == reflect.Map || kind == reflect.Slice) && !option.isSet {
@@ -327,7 +327,7 @@ func (option *Option) clearDefault() {
 		option.empty()
 
 		for _, d := range usedDefault {
-			option.set(&d)
+			option.Set(&d)
 			option.isSetDefault = true
 		}
 	} else {

--- a/parser.go
+++ b/parser.go
@@ -523,7 +523,7 @@ func (p *Parser) parseOption(s *parseState, name string, option *Option, canarg 
 			return newErrorf(ErrNoArgumentForBool, "bool flag `%s' cannot have an argument", option)
 		}
 
-		err = option.set(nil)
+		err = option.Set(nil)
 	} else if argument != nil || (canarg && !s.eof()) {
 		var arg string
 
@@ -544,13 +544,13 @@ func (p *Parser) parseOption(s *parseState, name string, option *Option, canarg 
 		}
 
 		if err == nil {
-			err = option.set(&arg)
+			err = option.Set(&arg)
 		}
 	} else if option.OptionalArgument {
 		option.empty()
 
 		for _, v := range option.OptionalValue {
-			err = option.set(&v)
+			err = option.Set(&v)
 
 			if err != nil {
 				break


### PR DESCRIPTION
To allow client applications to use the library in interesting new ways.
Specifically to present a web interface alternative for setting options,
but still being able to use this library.

I used it to be able to give a web interface to [my tool](http://schemaexplorer.io/)'s setup while keeping command line args and DRY code.
See it in action https://www.youtube.com/watch?v=5IN77qiHnq8

Thanks for a fab library, it really helped with my project, particularly allowing it to be [12-factor](https://12factor.net/config)