### PR TITLE
Use UnknownOptionHandler for unknown ini options

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -526,7 +526,13 @@ func (i *IniParser) parse(ini *ini) error {
 			}
 
 			if opt == nil {
-				if (p.Options & IgnoreUnknown) == None {
+				if (p.Options&IniUnknownOptionHandler) != None && p.UnknownOptionHandler != nil {
+					_, err := p.UnknownOptionHandler(inival.Name, strArgument{&inival.Value}, nil)
+
+					if err != nil {
+						return err
+					}
+				} else if (p.Options & IgnoreUnknown) == None {
 					return &IniError{
 						Message:    fmt.Sprintf("unknown option: %s", inival.Name),
 						File:       ini.File,

--- a/parser.go
+++ b/parser.go
@@ -112,6 +112,15 @@ const (
 	// POSIX processing.
 	PassAfterNonOption
 
+	// IniUnknownOptionHandler invokes the UnknownOptionHandler when an unknown
+	// ini option is parsed. When UnknownOptionHandler is invoked with an unknown
+	// ini option, the function will recieve the ini option name, the ini value
+	// as a SplitArgument and the last argment will always be nil. With this
+	// option is specified, you must ensure your UnknownOptionHandler can handle
+	// both a slice of remaining arguments, as used with an unknown argument, and
+	// nil, as used with an unknown ini option.
+	IniUnknownOptionHandler
+
 	// Default is a convenient default set of options which should cover
 	// most of the uses of the flags package.
 	Default = HelpFlag | PrintErrors | PassDoubleDash


### PR DESCRIPTION
I have found the need to parse unknown ini options, there are two possible ways to do this:

1. Add another handler (e.g. `UnknownIniOptionHandler`)
2. Use the existing handler, without passing the last argument

I have gone with the second option for now, as this was the best in my case, I have added a `IniUnknownOptionHandler` option which can be used to enable this functionality.

Let me know if you'd prefer to just use another handler, or if you'd like this implemented in some other way :)