### PR TITLE
Use golang.org/x/sys/unix to determine terminal width

### DIFF
--- a/check_crosscompile.sh
+++ b/check_crosscompile.sh
@@ -16,3 +16,5 @@ echo '# freebsd'
 GOARCH=amd64 GOOS=freebsd go build
 echo '# aix ppc64'
 GOARCH=ppc64 GOOS=aix go build
+echo '# solaris amd64'
+GOARCH=amd64 GOOS=solaris go build

--- a/check_crosscompile.sh
+++ b/check_crosscompile.sh
@@ -14,3 +14,5 @@ echo '# darwin'
 GOARCH=amd64 GOOS=darwin go build
 echo '# freebsd'
 GOARCH=amd64 GOOS=freebsd go build
+echo '# aix ppc64'
+GOARCH=ppc64 GOOS=aix go build

--- a/termsize.go
+++ b/termsize.go
@@ -1,28 +1,15 @@
-// +build !windows,!plan9,!solaris,!appengine,!wasm
+// +build !windows,!plan9,!appengine,!wasm
 
 package flags
 
 import (
-	"syscall"
-	"unsafe"
+	"golang.org/x/sys/unix"
 )
 
-type winsize struct {
-	row, col       uint16
-	xpixel, ypixel uint16
-}
-
 func getTerminalColumns() int {
-	ws := winsize{}
-
-	if tIOCGWINSZ != 0 {
-		syscall.Syscall(syscall.SYS_IOCTL,
-			uintptr(0),
-			uintptr(tIOCGWINSZ),
-			uintptr(unsafe.Pointer(&ws)))
-
-		return int(ws.col)
+	ws, err := unix.IoctlGetWinsize(0, unix.TIOCGWINSZ)
+	if err != nil {
+		return 80
 	}
-
-	return 80
+	return int(ws.Col)
 }

--- a/termsize_nosysioctl.go
+++ b/termsize_nosysioctl.go
@@ -1,4 +1,4 @@
-// +build plan9 solaris appengine wasm
+// +build plan9 appengine wasm
 
 package flags
 

--- a/tiocgwinsz_bsdish.go
+++ b/tiocgwinsz_bsdish.go
@@ -1,7 +1,0 @@
-// +build darwin freebsd netbsd openbsd
-
-package flags
-
-const (
-	tIOCGWINSZ = 0x40087468
-)

--- a/tiocgwinsz_linux.go
+++ b/tiocgwinsz_linux.go
@@ -1,7 +1,0 @@
-// +build linux
-
-package flags
-
-const (
-	tIOCGWINSZ = 0x5413
-)

--- a/tiocgwinsz_other.go
+++ b/tiocgwinsz_other.go
@@ -1,7 +1,0 @@
-// +build !darwin,!freebsd,!netbsd,!openbsd,!linux
-
-package flags
-
-const (
-	tIOCGWINSZ = 0
-)


### PR DESCRIPTION
Use IoctlGetWinsize from golang.org/x/sys/unix to determine terminal width. This is the same mechanism used in golang.org/x/crypto/ssh/terminal.

This enables go-flags compilation on AIX (tested cross compile using go 1.12.5 and using gccgo 1.10.3) without needing more custom platform-specific TIOCGWINSZ constants. (Also, syscall.SYS_IOCTL is not defined on AIX.)

Cross-compilation succeeds for all the platforms in check_crosscompile.sh using go 1.12.5. I am unable to test on all of them but have verified the new code behaves correctly on Linux and AIX.