### PR TITLE
Add safe build tag to avoid all unsafe usage.

### DIFF
--- a/termsize.go
+++ b/termsize.go
@@ -1,4 +1,4 @@
-// +build !windows,!plan9,!solaris,!appengine,!wasm
+// +build !safe,!windows,!plan9,!solaris,!appengine,!wasm
 
 package flags
 

--- a/termsize_nosysioctl.go
+++ b/termsize_nosysioctl.go
@@ -1,4 +1,4 @@
-// +build plan9 solaris appengine wasm
+// +build safe plan9 solaris appengine wasm
 
 package flags
 

--- a/termsize_windows.go
+++ b/termsize_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows,!safe
 
 package flags
 


### PR DESCRIPTION
Even on platforms where unsafe is permitted, it is not always
desirable to include additional unsafe usage.  This change introduces
a 'safe' build tag which forgoes the terminal width detection on all
platforms to force a memory-safe build.

**This needs testing on windows** but it does cross compile for windows with and without the safe build tag.