### PR TITLE
completion: do not complete hidden commands

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -130,7 +130,7 @@ func (c *completion) completeCommands(s *parseState, match string) []Completion 
 	n := make([]Completion, 0, len(s.command.commands))
 
 	for _, cmd := range s.command.commands {
-		if cmd.data != c && strings.HasPrefix(cmd.Name, match) {
+		if cmd.data != c && !cmd.Hidden && strings.HasPrefix(cmd.Name, match) {
 			n = append(n, Completion{
 				Item:        cmd.Name,
 				Description: cmd.ShortDescription,

--- a/completion_test.go
+++ b/completion_test.go
@@ -68,6 +68,9 @@ var completionTestOptions struct {
 	RenameCommand struct {
 		Completed TestComplete `short:"c" long:"completed"`
 	} `command:"rename" description:"rename an item"`
+
+	HiddenCommand struct {
+	} `command:"hidden" description:"hidden command" hidden:"true"`
 }
 
 type completionTest struct {


### PR DESCRIPTION
Declaring the command hidden it does not show up in help or man. It
should also not appear in completion output.