### PR TITLE
fixes #323 - Required slice option

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -498,7 +498,9 @@ func (i *IniParser) matchingGroups(name string) []*Group {
 
 func (i *IniParser) parse(ini *ini) error {
 	p := i.parser
-
+	p.eachOption(func(c *Command, g *Group, o *Option) {
+		o.isProcessingIni = true
+	})
 	var quotesLookup = make(map[*Option]bool)
 
 	for name, section := range ini.Sections {
@@ -579,6 +581,7 @@ func (i *IniParser) parse(ini *ini) error {
 					LineNumber: inival.LineNumber,
 				}
 			}
+			opt.setFromIni = true
 
 			// either all INI values are quoted or only values who need quoting
 			if _, ok := quotesLookup[opt]; !inival.Quoted || !ok {

--- a/ini_test.go
+++ b/ini_test.go
@@ -257,6 +257,31 @@ EnvDefault2 = env-def
 	}
 }
 
+func TestIniRequiredSlice_ShouldNotNeedToBeSpecifiedOnCli(t *testing.T) {
+	type options struct {
+		Items []string `long:"item" required:"true"`
+	}
+	var opts options
+	ini := `
+[Application Options]
+item=abc`
+	args := []string{}
+
+	parser := NewParser(&opts, Default)
+	inip := NewIniParser(parser)
+
+	inip.Parse(strings.NewReader(ini))
+	inip.ParseAsDefaults = false
+	_, err := parser.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("Unexpected failure: %v", err)
+	}
+	if opts.Items[0] != "abc" {
+		t.Fatalf("Expected first option to be abc, but was %v", opts.Items[0])
+	}
+
+}
+
 func TestReadIni_flagEquivalent(t *testing.T) {
 	type options struct {
 		Opt1 bool `long:"opt1"`

--- a/option.go
+++ b/option.go
@@ -86,6 +86,9 @@ type Option struct {
 	preventDefault bool
 
 	defaultLiteral string
+
+	isProcessingIni bool
+	setFromIni      bool
 }
 
 // LongNameWithNamespace returns the option's long name with the group namespaces
@@ -241,8 +244,9 @@ func (option *Option) IsSetDefault() bool {
 func (option *Option) set(value *string) error {
 	kind := option.value.Type().Kind()
 
-	if (kind == reflect.Map || kind == reflect.Slice) && !option.isSet {
+	if (kind == reflect.Map || kind == reflect.Slice) && (!option.isSet || (!option.isProcessingIni && option.setFromIni)) {
 		option.empty()
+		option.setFromIni = false
 	}
 
 	option.isSet = true

--- a/parser.go
+++ b/parser.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -207,7 +208,10 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 	}
 
 	p.eachOption(func(c *Command, g *Group, option *Option) {
-		option.isSet = false
+		option.isProcessingIni = false
+		if !(option.value.Kind() == reflect.Slice || option.value.Kind() == reflect.Map) {
+			option.isSet = false
+		}
 		option.isSetDefault = false
 		option.updateDefaultLiteral()
 	})


### PR DESCRIPTION
Maintains state to keep track of when switching over from parsing INI to CLI and clears slice/map options based on that.