### PR TITLE
IniParser: write 'func' options with "ini-name"

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -216,7 +216,7 @@ func writeGroupIni(cmd *Command, group *Group, namespace string, writer io.Write
 	comments := (options & IniIncludeComments) != IniNone
 
 	for _, option := range group.options {
-		if option.isFunc() || option.Hidden {
+		if option.Hidden || option.isFunc() && len(option.tag.Get("ini-name")) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
If a 'ini-name' tag is set on the option, write it to file even if the
option is a function.