### PR TITLE
ini: fix IniParser.write() for zero values

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -53,7 +53,7 @@ func getBase(options multiTag, base int) (int, error) {
 
 func convertMarshal(val reflect.Value) (bool, string, error) {
 	// Check first for the Marshaler interface
-	if val.Type().NumMethod() > 0 && val.CanInterface() {
+	if val.IsValid() && val.Type().NumMethod() > 0 && val.CanInterface() {
 		if marshaler, ok := val.Interface().(Marshaler); ok {
 			ret, err := marshaler.MarshalFlag()
 			return true, ret, err
@@ -66,6 +66,10 @@ func convertMarshal(val reflect.Value) (bool, string, error) {
 func convertToString(val reflect.Value, options multiTag) (string, error) {
 	if ok, ret, err := convertMarshal(val); ok {
 		return ret, err
+	}
+
+	if !val.IsValid() {
+		return "", nil
 	}
 
 	tp := val.Type()


### PR DESCRIPTION
Fixes two different panics when using `IniParser.Write()`:

```
[Application Options]
panic: reflect: call of reflect.Value.IsZero on zero Value

goroutine 1 [running]:
reflect.Value.IsZero(0x0, 0x0, 0x0, 0xc0005071f0)
	/usr/local/Cellar/go/1.13.7/libexec/src/reflect/value.go:1121 +0x638
github.com/jessevdk/go-flags.convertMarshal(0x0, 0x0, 0x0, 0x4030751, 0x4ce1e40, 0xc000507258, 0xc000507248, 0x40cb502)
	third_party/go/src/github.com/jessevdk/go-flags/convert.go:56 +0x43
github.com/jessevdk/go-flags.convertToString(0x0, 0x0, 0x0, 0x4b87dd2, 0x8c, 0xc0001e4d80, 0x0, 0x0, 0x559b6e0, 0xc000530100)
	third_party/go/src/github.com/jessevdk/go-flags/convert.go:67 +0x5a
github.com/jessevdk/go-flags.convertToString(0x4aa5b40, 0xc000226a50, 0x196, 0x4b87dd2, 0x8c, 0xc0001e4d80, 0x1, 0x16, 0x0, 0x0)
	third_party/go/src/github.com/jessevdk/go-flags/convert.go:153 +0xbe5
github.com/jessevdk/go-flags.writeGroupIni(0xc00036c280, 0xc00025bc20, 0x0, 0x0, 0x4ee9f20, 0xc000010018, 0x2)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:284 +0x5b0
github.com/jessevdk/go-flags.writeCommandIni.func1(0xc00025bc20)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:323 +0x72
github.com/jessevdk/go-flags.(*Group).eachGroup(0xc00025bc20, 0xc0005077c8)
	third_party/go/src/github.com/jessevdk/go-flags/group.go:184 +0x30
github.com/jessevdk/go-flags.(*Group).eachGroup(0xc00025bb80, 0xc0005077c8)
	third_party/go/src/github.com/jessevdk/go-flags/group.go:187 +0x67
github.com/jessevdk/go-flags.writeCommandIni(0xc00036c280, 0x0, 0x0, 0x4ee9f20, 0xc000010018, 0x2)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:321 +0xcc
github.com/jessevdk/go-flags.writeIni(...)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:345
github.com/jessevdk/go-flags.(*IniParser).Write(0xc00019c690, 0x4ee9f20, 0xc000010018, 0x2)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:157 +0x59
```

and

```
[Application Options]
panic: reflect: call of reflect.Value.Type on zero Value

goroutine 1 [running]:
reflect.Value.Type(0x0, 0x0, 0x0, 0x4030700, 0x0)
	/usr/local/Cellar/go/1.13.7/libexec/src/reflect/value.go:1877 +0x166
github.com/jessevdk/go-flags.convertToString(0x0, 0x0, 0x0, 0x4b87db2, 0x8c, 0xc000318d80, 0x0, 0x0, 0x559b6e0, 0xc00050c080)
	third_party/go/src/github.com/jessevdk/go-flags/convert.go:71 +0xa4
github.com/jessevdk/go-flags.convertToString(0x4aa5b20, 0xc000226a50, 0x196, 0x4b87db2, 0x8c, 0xc000318d80, 0x1, 0x16, 0x0, 0x0)
	third_party/go/src/github.com/jessevdk/go-flags/convert.go:153 +0xbe5
github.com/jessevdk/go-flags.writeGroupIni(0xc000338380, 0xc000257d60, 0x0, 0x0, 0x4ee9f00, 0xc000010018, 0x2)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:284 +0x5b0
github.com/jessevdk/go-flags.writeCommandIni.func1(0xc000257d60)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:323 +0x72
github.com/jessevdk/go-flags.(*Group).eachGroup(0xc000257d60, 0xc00049f7c8)
	third_party/go/src/github.com/jessevdk/go-flags/group.go:184 +0x30
github.com/jessevdk/go-flags.(*Group).eachGroup(0xc000257cc0, 0xc00049f7c8)
	third_party/go/src/github.com/jessevdk/go-flags/group.go:187 +0x67
github.com/jessevdk/go-flags.writeCommandIni(0xc000338380, 0x0, 0x0, 0x4ee9f00, 0xc000010018, 0x2)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:321 +0xcc
github.com/jessevdk/go-flags.writeIni(...)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:345
github.com/jessevdk/go-flags.(*IniParser).Write(0xc00019c980, 0x4ee9f00, 0xc000010018, 0x2)
	third_party/go/src/github.com/jessevdk/go-flags/ini.go:157 +0x59
```