### PR TITLE
return err for invalid env default value

### DIFF
--- a/option.go
+++ b/option.go
@@ -308,7 +308,7 @@ func (option *Option) empty() {
 	}
 }
 
-func (option *Option) clearDefault() {
+func (option *Option) clearDefault() error {
 	usedDefault := option.Default
 
 	if envKey := option.EnvKeyWithNamespace(); envKey != "" {
@@ -327,7 +327,10 @@ func (option *Option) clearDefault() {
 		option.empty()
 
 		for _, d := range usedDefault {
-			option.set(&d)
+			err := option.set(&d)
+			if err != nil {
+				return err
+			}
 			option.isSetDefault = true
 		}
 	} else {
@@ -344,6 +347,8 @@ func (option *Option) clearDefault() {
 			}
 		}
 	}
+
+	return nil
 }
 
 func (option *Option) valueIsDefault() bool {

--- a/parser.go
+++ b/parser.go
@@ -314,7 +314,10 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 				return
 			}
 
-			option.clearDefault()
+			err := option.clearDefault()
+			if err != nil {
+				s.err = err
+			}
 		})
 
 		s.checkRequired(p)

--- a/parser_test.go
+++ b/parser_test.go
@@ -260,10 +260,11 @@ type envDefaultOptions struct {
 
 func TestEnvDefaults(t *testing.T) {
 	var tests = []struct {
-		msg      string
-		args     []string
-		expected envDefaultOptions
-		env      map[string]string
+		msg         string
+		args        []string
+		expected    envDefaultOptions
+		expectedErr string
+		env         map[string]string
 	}{
 		{
 			msg:  "no arguments, no env, expecting default values",
@@ -296,6 +297,14 @@ func TestEnvDefaults(t *testing.T) {
 				"TEST_M":     "a:2;b:3",
 				"TEST_S":     "4,5,6",
 				"NESTED_FOO": "a",
+			},
+		},
+		{
+			msg:         "no arguments, malformed env defaults, expecting parse error",
+			args:        []string{},
+			expectedErr: `parsing "two": invalid syntax`,
+			env: map[string]string{
+				"TEST_I": "two",
 			},
 		},
 		{
@@ -350,16 +359,24 @@ func TestEnvDefaults(t *testing.T) {
 			os.Setenv(envKey, envValue)
 		}
 		_, err := ParseArgs(&opts, test.args)
-		if err != nil {
-			t.Fatalf("%s:\nUnexpected error: %v", test.msg, err)
-		}
+		if test.expectedErr != "" {
+			if err == nil {
+				t.Errorf("%s:\nExpected error containing substring %q", test.msg, test.expectedErr)
+			} else if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("%s:\nExpected error %q to contain substring %q", test.msg, err, test.expectedErr)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("%s:\nUnexpected error: %v", test.msg, err)
+			}
 
-		if opts.Slice == nil {
-			opts.Slice = []int{}
-		}
+			if opts.Slice == nil {
+				opts.Slice = []int{}
+			}
 
-		if !reflect.DeepEqual(opts, test.expected) {
-			t.Errorf("%s:\nUnexpected options with arguments %+v\nexpected\n%+v\nbut got\n%+v\n", test.msg, test.args, test.expected, opts)
+			if !reflect.DeepEqual(opts, test.expected) {
+				t.Errorf("%s:\nUnexpected options with arguments %+v\nexpected\n%+v\nbut got\n%+v\n", test.msg, test.args, test.expected, opts)
+			}
 		}
 	}
 }


### PR DESCRIPTION
fixes #329

This change is pretty important for us because we use env vars not only as a way of providing defaults but as a way for users to configure our software in e.g. `docker-compose.yml`.

Without this change, bogus values do not raise errors, and this can cause nil panics in production code because it normally assumes that all flag values have been unmarshaled and any errors raised there will be respected. Rather than having to write defensive code, I think it would be better for env value defaults to behave the exact same as if they were specified via flags, as this allows us to push as much validation as possible into the parsing stage and catch errors as early as possible.

Thanks!