### PR TITLE
add support for autogeneration of option long flag and env

### DIFF
--- a/auto_generation_test.go
+++ b/auto_generation_test.go
@@ -1,0 +1,159 @@
+package flags
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+type options struct {
+	TestFlag1  string        `default:"default-value-1" description:"should be auto split"`
+	TestFlag2  string        `default:"default-value-2" long:"testflag2" description:"long specified"`
+	Test_Flag3 time.Duration `default:"5s" description:"split is specified in name"`
+	TestFlag4  int           `default:"4" env:"CUSTOM_FLAG" description:"specify ENV but not long"`
+}
+
+func assertOption(t *testing.T, p *Parser, expectedLong string, expectedEnv string, expectedValue interface{}) {
+	opt := p.FindOptionByLongName(expectedLong)
+	if opt == nil {
+		t.Fatalf("unable to find expected options: '%s'", expectedLong)
+	}
+	if opt.EnvDefaultKey != expectedEnv {
+		t.Fatalf("option did not have expected env key '%s'; got '%s'; expected '%s'",
+			expectedLong, opt.EnvDefaultKey, expectedEnv)
+	}
+	if opt.Value() != expectedValue {
+		t.Fatalf("option did not have expected value '%s'; got '%#+v'; expected '%#+v'",
+			expectedLong, opt.Value(), expectedValue)
+	}
+}
+
+func assertNoOption(t *testing.T, p *Parser, unexpectedLong string) {
+	opt := p.FindOptionByLongName(unexpectedLong)
+	if opt != nil {
+		t.Fatalf("found option that should not exist: '%s'", unexpectedLong)
+	}
+}
+
+func TestFullAutoGeneration(t *testing.T) {
+	var opts options
+	p := NewParser(&opts, Auto)
+	left, err := p.ParseArgs([]string{})
+	if err != nil {
+		t.Fatalf("parsing unexpectedly failed: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("didn't expect left over arguments, got %d (%+v)", len(left), left)
+	}
+
+	assertOption(t, p, "test_flag_1", "TEST_FLAG_1", "default-value-1")
+	assertOption(t, p, "testflag2", "TESTFLAG2", "default-value-2")
+	assertOption(t, p, "test_flag3", "TEST_FLAG3", 5*time.Second)
+	assertOption(t, p, "test_flag_4", "CUSTOM_FLAG", 4)
+}
+
+func TestOnlyLongAutoGeneration(t *testing.T) {
+	var opts options
+	p := NewParser(&opts, Default|AutoGenerateLong)
+	left, err := p.ParseArgs([]string{})
+	if err != nil {
+		t.Fatalf("parsing unexpectedly failed: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("didn't expect left over arguments, got %d (%+v)", len(left), left)
+	}
+
+	assertOption(t, p, "test_flag_1", "", "default-value-1")
+	assertOption(t, p, "testflag2", "", "default-value-2")
+	assertOption(t, p, "test_flag3", "", 5*time.Second)
+	assertOption(t, p, "test_flag_4", "CUSTOM_FLAG", 4)
+}
+
+func TestOnlyEnvAutoGeneration(t *testing.T) {
+	var opts options
+	p := NewParser(&opts, Default|AutoGenerateEnv)
+	left, err := p.ParseArgs([]string{})
+	if err != nil {
+		t.Fatalf("parsing unexpectedly failed: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("didn't expect left over arguments, got %d (%+v)", len(left), left)
+	}
+
+	assertNoOption(t, p, "test_flag_1")
+	assertOption(t, p, "testflag2", "TESTFLAG2", "default-value-2")
+	assertNoOption(t, p, "test_flag3")
+	assertNoOption(t, p, "test_flag_4")
+}
+
+func TestFullAutoGenerationWithEnv(t *testing.T) {
+	var opts options
+	p := NewParser(&opts, Auto)
+
+	os.Setenv("TEST_FLAG_1", "override1")
+	os.Setenv("TESTFLAG2", "override2")
+	os.Setenv("TEST_FLAG3", "10s")
+	os.Setenv("CUSTOM_FLAG", "-1")
+	left, err := p.ParseArgs([]string{})
+	if err != nil {
+		t.Fatalf("parsing unexpectedly failed: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("didn't expect left over arguments, got %d (%+v)", len(left), left)
+	}
+
+	assertOption(t, p, "test_flag_1", "TEST_FLAG_1", "override1")
+	assertOption(t, p, "testflag2", "TESTFLAG2", "override2")
+	assertOption(t, p, "test_flag3", "TEST_FLAG3", 10*time.Second)
+	assertOption(t, p, "test_flag_4", "CUSTOM_FLAG", -1)
+}
+
+func TestFullAutoGenerationWithFlags(t *testing.T) {
+	var opts options
+	p := NewParser(&opts, Auto)
+
+	left, err := p.ParseArgs([]string{
+		"--test_flag_1=override1-1",
+		"--testflag2=override2-2",
+		"--test_flag3=15s",
+		"--test_flag_4=42",
+	})
+	if err != nil {
+		t.Fatalf("parsing unexpectedly failed: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("didn't expect left over arguments, got %d (%+v)", len(left), left)
+	}
+
+	assertOption(t, p, "test_flag_1", "TEST_FLAG_1", "override1-1")
+	assertOption(t, p, "testflag2", "TESTFLAG2", "override2-2")
+	assertOption(t, p, "test_flag3", "TEST_FLAG3", 15*time.Second)
+	assertOption(t, p, "test_flag_4", "CUSTOM_FLAG", 42)
+}
+
+func TestFullAutoGenerationWithEnvAndFlags(t *testing.T) {
+	var opts options
+	p := NewParser(&opts, Auto)
+
+	os.Setenv("TEST_FLAG_1", "override1")
+	os.Setenv("TESTFLAG2", "override2")
+	os.Setenv("TEST_FLAG3", "10s")
+	os.Setenv("CUSTOM_FLAG", "-1")
+	left, err := p.ParseArgs([]string{
+		"--test_flag_1=override1-1",
+		"--testflag2=override2-2",
+		"--test_flag3=15s",
+		"--test_flag_4=42",
+	})
+	if err != nil {
+		t.Fatalf("parsing unexpectedly failed: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("didn't expect left over arguments, got %d (%+v)", len(left), left)
+	}
+
+	assertOption(t, p, "test_flag_1", "TEST_FLAG_1", "override1-1")
+	assertOption(t, p, "testflag2", "TESTFLAG2", "override2-2")
+	assertOption(t, p, "test_flag3", "TEST_FLAG3", 15*time.Second)
+	assertOption(t, p, "test_flag_4", "CUSTOM_FLAG", 42)
+}

--- a/command.go
+++ b/command.go
@@ -30,6 +30,9 @@ type Command struct {
 	// Whether positional arguments are required
 	ArgsRequired bool
 
+	// Parser Options
+	ParserOptions Options
+
 	commands            []*Command
 	hasBuiltinHelpGroup bool
 	args                []*Arg
@@ -66,7 +69,7 @@ type lookup struct {
 // options are in the command. The provided data can implement the Command and
 // Usage interfaces.
 func (c *Command) AddCommand(command string, shortDescription string, longDescription string, data interface{}) (*Command, error) {
-	cmd := newCommand(command, shortDescription, longDescription, data)
+	cmd := newCommand(command, shortDescription, longDescription, data, c.ParserOptions)
 
 	cmd.parent = c
 
@@ -85,6 +88,7 @@ func (c *Command) AddGroup(shortDescription string, longDescription string, data
 	group := newGroup(shortDescription, longDescription, data)
 
 	group.parent = c
+	group.ParserOptions = c.ParserOptions
 
 	if err := group.scanType(c.scanSubcommandHandler(group)); err != nil {
 		return nil, err
@@ -145,10 +149,11 @@ func (c *Command) Args() []*Arg {
 	return ret
 }
 
-func newCommand(name string, shortDescription string, longDescription string, data interface{}) *Command {
+func newCommand(name string, shortDescription string, longDescription string, data interface{}, parserOptions Options) *Command {
 	return &Command{
-		Group: newGroup(shortDescription, longDescription, data),
-		Name:  name,
+		Group:         newGroup(shortDescription, longDescription, data),
+		Name:          name,
+		ParserOptions: parserOptions,
 	}
 }
 

--- a/group.go
+++ b/group.go
@@ -7,6 +7,7 @@ package flags
 import (
 	"errors"
 	"reflect"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 )
@@ -15,6 +16,12 @@ import (
 // a pointer to a struct. Only pointers to structs are valid data containers
 // for options.
 var ErrNotPointerToStruct = errors.New("provided data is not a pointer to struct")
+
+// gattherRegexp used to find camel case words in the field names
+var gatherRegexp = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z0-9]+|[A-Z]+|[0-9]+)")
+
+// acronymRegexp used to identify acronyms in the field names
+var acronymRegexp = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
 
 // Group represents an option group. Option groups can be used to logically
 // group options together under a description. Groups are only used to provide
@@ -40,6 +47,9 @@ type Group struct {
 	// If true, the group is not displayed in the help or man page
 	Hidden bool
 
+	// Pay forward the parser options
+	ParserOptions Options
+
 	// The parent of the group or nil if it has no parent
 	parent interface{}
 
@@ -57,6 +67,29 @@ type Group struct {
 
 type scanHandler func(reflect.Value, *reflect.StructField) (bool, error)
 
+func splitWords(name, sep string) string {
+
+	// If already split then accept it
+	if strings.Index(name, "_") != -1 {
+		return name
+	}
+
+	words := gatherRegexp.FindAllStringSubmatch(name, -1)
+	if len(words) == 0 {
+		return name
+	}
+
+	var key []string
+	for _, words := range words {
+		if m := acronymRegexp.FindStringSubmatch(words[0]); len(m) == 3 {
+			key = append(key, m[1], m[2])
+		} else {
+			key = append(key, words[0])
+		}
+	}
+	return strings.Join(key, sep)
+}
+
 // AddGroup adds a new group to the command with the given name and data. The
 // data needs to be a pointer to a struct from which the fields indicate which
 // options are in the group.
@@ -64,6 +97,7 @@ func (g *Group) AddGroup(shortDescription string, longDescription string, data i
 	group := newGroup(shortDescription, longDescription, data)
 
 	group.parent = g
+	group.ParserOptions = g.ParserOptions
 
 	if err := group.scan(); err != nil {
 		return nil, err
@@ -249,6 +283,10 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		longname := mtag.Get("long")
 		shortname := mtag.Get("short")
 
+		if longname == "" && g.ParserOptions&AutoGenerateLong != 0 {
+			longname = strings.ToLower(splitWords(field.Name, "_"))
+		}
+
 		// Need at least either a short or long name
 		if longname == "" && shortname == "" && mtag.Get("ini-name") == "" {
 			continue
@@ -277,13 +315,17 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		required := !isStringFalsy(mtag.Get("required"))
 		choices := mtag.GetMany("choice")
 		hidden := !isStringFalsy(mtag.Get("hidden"))
+		env := mtag.Get("env")
+		if env == "" && g.ParserOptions&AutoGenerateEnv != 0 {
+			env = strings.ToUpper(longname)
+		}
 
 		option := &Option{
 			Description:      description,
 			ShortName:        short,
 			LongName:         longname,
 			Default:          def,
-			EnvDefaultKey:    mtag.Get("env"),
+			EnvDefaultKey:    env,
 			EnvDefaultDelim:  mtag.Get("env-delim"),
 			OptionalArgument: optional,
 			OptionalValue:    optionalValue,

--- a/parser.go
+++ b/parser.go
@@ -112,9 +112,21 @@ const (
 	// POSIX processing.
 	PassAfterNonOption
 
+	// AutoGenerateLong if long is not specified as an option it will be
+	// auto generated based on the struct field name
+	AutoGenerateLong
+
+	// AutoGenerateEnv if env is not specified as an option it will be
+	// auto generated based on the struct field name
+	AutoGenerateEnv
+
 	// Default is a convenient default set of options which should cover
 	// most of the uses of the flags package.
 	Default = HelpFlag | PrintErrors | PassDoubleDash
+
+	// Auto is a conenient value that combines Default with the auto
+	// generating flags
+	Auto = Default | AutoGenerateLong | AutoGenerateEnv
 )
 
 type parseState struct {
@@ -173,7 +185,7 @@ func NewParser(data interface{}, options Options) *Parser {
 // be added to this parser by using AddGroup and AddCommand.
 func NewNamedParser(appname string, options Options) *Parser {
 	p := &Parser{
-		Command:               newCommand(appname, "", "", nil),
+		Command:               newCommand(appname, "", "", nil, options),
 		Options:               options,
 		NamespaceDelimiter:    ".",
 		EnvNamespaceDelimiter: "_",


### PR DESCRIPTION
Added support for two parser options
        // AutoGenerateLong if long is not specified as an option it will be
        // auto generated based on the struct field name
        AutoGenerateLong

        // AutoGenerateEnv if env is not specified as an option it will be
        // auto generated based on the struct field name
        AutoGenerateEnv

And an additional convenience set
        // Auto is a convenient value that combines Default with the auto
        // generating flags
        Auto = Default | AutoGenerateLong | AutoGenerateEnv

Together these options can be used to enable the generation of long name and env based
on the struct field name taking into account camelcase.

```
OneTwoThree -> 
long: one_two_three
env: ONE_TWO_THREE
```

If `long` or `env` are specified those are kept. if the field already has a `_` in the name it is not split. If `long` is specified, but `env` is not then the `env` value is copied from the specified `long`.