### PR TITLE
Help positional args dependet from arg.Required

### DIFF
--- a/help.go
+++ b/help.go
@@ -334,7 +334,11 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 				}
 
 				if !allcmd.ArgsRequired {
-					fmt.Fprintf(wr, "[%s]", name)
+					if arg.Required > 0 {
+						fmt.Fprintf(wr, "%s", name)
+				    } else {
+						fmt.Fprintf(wr, "[%s]", name)
+				    }
 				} else {
 					fmt.Fprintf(wr, "%s", name)
 				}


### PR DESCRIPTION
Have 2 positional argument in the my project - one required and one optional

```go
type Options struct {
	Verbose		bool	`short:"v" long:"verbose" description:"Show verbose debug information"`
	Extensions	string 	`short:"e" long:"ext" description:"Executable extensions" default:"exe|bat"`
	Positional struct {
		Filepath string `positional-arg-name:"filepath"`
		Filename string `positional-arg-name:"filename"`
	} `positional-args:"yes"  required:"yes"`
```
generate help
```bash
Usage:
  deepfindexe [OPTIONS] filepath filename
```
without Positional `required:"yes"` generate help
```bash
Usage:
  deepfindexe [OPTIONS] [filepath] [filename]
```
With this patch for Options
```go
type Options struct {
	Verbose		bool	`short:"v" long:"verbose" description:"Show verbose debug information"`
	Extensions	string 	`short:"e" long:"ext" description:"Executable extensions" default:"exe|bat"`
	Positional struct {
		Filepath string `positional-arg-name:"filepath"   required:"yes"`
		Filename string `positional-arg-name:"filename"`
	} `positional-args:"yes"`
```
generate help
```bash
Usage:
  deepfindexe [OPTIONS] filepath [filename]
```

