### PR TITLE
Help for positional args without allcmd.ArgsRequired dependent from arg.Required

### DIFF
--- a/help.go
+++ b/help.go
@@ -334,7 +334,11 @@ func (p *Parser) WriteHelp(writer io.Writer) {
 				}
 
 				if !allcmd.ArgsRequired {
-					fmt.Fprintf(wr, "[%s]", name)
+					if arg.Required > 0 {
+						fmt.Fprintf(wr, "%s", name)
+					} else {
+						fmt.Fprintf(wr, "[%s]", name)
+					}
 				} else {
 					fmt.Fprintf(wr, "%s", name)
 				}

--- a/help_test.go
+++ b/help_test.go
@@ -107,7 +107,7 @@ func TestHelp(t *testing.T) {
 
 		if runtime.GOOS == "windows" {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command | parent>
+  TestHelp [OPTIONS] [filename] [num] hidden-in-help <bommand | command | parent>
 
 Application Options:
   /v, /verbose                              Show verbose debug information
@@ -156,7 +156,7 @@ Available commands:
 `
 		} else {
 			expected = `Usage:
-  TestHelp [OPTIONS] [filename] [num] [hidden-in-help] <bommand | command | parent>
+  TestHelp [OPTIONS] [filename] [num] hidden-in-help <bommand | command | parent>
 
 Application Options:
   -v, --verbose                             Show verbose debug information


### PR DESCRIPTION
In my project have 2 positional argument - one required and other optional.
Now help print both optional or required dependent from  allcmd.ArgsRequired

```go
type Options struct {
	Verbose		bool	`short:"v" long:"verbose" description:"Show verbose debug information"`
	Extensions	string 	`short:"e" long:"ext" description:"Executable extensions" default:"bat|exe"`
	Positional struct {
		Filepath string `positional-arg-name:"filepath" required:"yes"`
		Filename string `positional-arg-name:"filename"`
	} `positional-args:"yes"`
}
```
now help print
```bash
Usage:
  deepfindexe [OPTIONS] [filepath] [filename]
```
with this patch print
```bash
Usage:
  deepfindexe [OPTIONS] filepath [filename]
```
