### PR TITLE
Document return value of Parse/ParseArgs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -129,8 +129,7 @@ type parseState struct {
 }
 
 // Parse is a convenience function to parse command line options with default
-// settings. The provided data is a pointer to a struct representing the
-// default option group (named "Application Options"). For more control, use
+// settings. For more detailed information see ParseArgs. For more control, use
 // flags.NewParser.
 func Parse(data interface{}) ([]string, error) {
 	return NewParser(data, Default).Parse()
@@ -139,9 +138,11 @@ func Parse(data interface{}) ([]string, error) {
 // ParseArgs is a convenience function to parse command line options with default
 // settings. The provided data is a pointer to a struct representing the
 // default option group (named "Application Options"). The args argument is
-// the list of command line arguments to parse. If you just want to parse the
-// default program command line arguments (i.e. os.Args), then use flags.Parse
-// instead. For more control, use flags.NewParser.
+// the list of command line arguments to parse. On successful parsing of the
+// arguments, the remaining, non-option, arguments (if any) are returned. If
+// you just want to parse the default program command line arguments (i.e.
+// os.Args), then use flags.Parse instead. For more control, use
+// flags.NewParser.
 func ParseArgs(data interface{}, args []string) ([]string, error) {
 	return NewParser(data, Default).ParseArgs(args)
 }


### PR DESCRIPTION
The return value of the plain Parse/ParseArgs functions aren't explained unless you dig down as far as (*Parser) ParseArgs.

This commit copies that information up to Parse/ParseArgs too.