### PR TITLE
Add parser builder to modify parser options in-place

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,19 @@
+package flags
+
+// WithOptions sets Options to parser
+func (p *Parser) WithOptions(options Options) *Parser {
+	p.Options = options
+	return p
+}
+
+// WithNamespaceDelimiter sets NamespaceDelimiter to parser
+func (p *Parser) WithNamespaceDelimiter(delim string) *Parser {
+	p.NamespaceDelimiter = delim
+	return p
+}
+
+// WithEnvNamespaceDelimiter sets EnvNamespaceDelimiter to parser
+func (p *Parser) WithEnvNamespaceDelimiter(delim string) *Parser {
+	p.EnvNamespaceDelimiter = delim
+	return p
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,29 @@
+package flags
+
+import (
+	"testing"
+)
+
+func TestParserBuilder(t *testing.T) {
+	type Opts struct {
+		Value  bool `short:"v"`
+		Nested struct {
+			Foo string `long:"foo" default:"z" env:"FOO"`
+		} `group:"nested" namespace:"nested" env-namespace:"NESTED"`
+	}
+
+	var opts = Opts{}
+	var err error
+
+	_, err = NewParser(&opts, None).WithNamespaceDelimiter("_").ParseArgs([]string{"--nested_foo=\"val\""})
+	if err != nil {
+		assertErrorf(t, "Parser returned unexpected error %v", err)
+	}
+	assertString(t, opts.Nested.Foo, "val")
+
+	_, err = NewParser(&opts, None).WithNamespaceDelimiter("-").ParseArgs([]string{"--nested-foo=\"val\""})
+	if err != nil {
+		assertErrorf(t, "Parser returned unexpected error %v", err)
+	}
+	assertString(t, opts.Nested.Foo, "val")
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -15,13 +15,13 @@ func TestParserBuilder(t *testing.T) {
 	var opts = Opts{}
 	var err error
 
-	_, err = NewParser(&opts, None).WithNamespaceDelimiter("_").ParseArgs([]string{"--nested_foo=\"val\""})
+	_, err = NewDefaultParser(&opts).WithNamespaceDelimiter("_").ParseArgs([]string{"--nested_foo=\"val\""})
 	if err != nil {
 		assertErrorf(t, "Parser returned unexpected error %v", err)
 	}
 	assertString(t, opts.Nested.Foo, "val")
 
-	_, err = NewParser(&opts, None).WithNamespaceDelimiter("-").ParseArgs([]string{"--nested-foo=\"val\""})
+	_, err = NewDefaultParser(&opts).WithNamespaceDelimiter("-").ParseArgs([]string{"--nested-foo=\"val\""})
 	if err != nil {
 		assertErrorf(t, "Parser returned unexpected error %v", err)
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/jessevdk/go-flags"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type EditorOptions struct {
@@ -66,7 +67,7 @@ type Options struct {
 
 var options Options
 
-var parser = flags.NewParser(&options, flags.Default)
+var parser = flags.NewParser(&options, flags.Default).WithNamespaceDelimiter("_")
 
 func main() {
 	if _, err := parser.Parse(); err != nil {

--- a/parser.go
+++ b/parser.go
@@ -133,7 +133,7 @@ type parseState struct {
 // default option group (named "Application Options"). For more control, use
 // flags.NewParser.
 func Parse(data interface{}) ([]string, error) {
-	return NewParser(data, Default).Parse()
+	return NewDefaultParser(data).Parse()
 }
 
 // ParseArgs is a convenience function to parse command line options with default
@@ -166,6 +166,11 @@ func NewParser(data interface{}, options Options) *Parser {
 	}
 
 	return p
+}
+
+// NewDefaultParser acts like NewParser, but initializes options with Default.
+func NewDefaultParser(data interface{}) *Parser {
+	return NewParser(data, Default)
 }
 
 // NewNamedParser creates a new parser. The appname is used to display the


### PR DESCRIPTION
In some cases it is convenient to do `NewParser(...).Parse()` in one line, but some parser configuration needs to be changed. This PR suggests changes for creating parser like `NewDefaultParser(&opts).WithOptions(...).WithEnvNamespaceDelimiter(...).Parse()`