### PR TITLE
fix a panic when generating help while the subcommand and all option groups are hidden

### DIFF
--- a/help.go
+++ b/help.go
@@ -72,15 +72,15 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 	var prevcmd *Command
 
 	p.eachActiveGroup(func(c *Command, grp *Group) {
-		if !grp.showInHelp() {
-			return
-		}
 		if c != prevcmd {
 			for _, arg := range c.args {
 				ret.updateLen(arg.Name, c != p.Command)
 			}
+			prevcmd = c
 		}
-
+		if !grp.showInHelp() {
+			return
+		}
 		for _, info := range grp.options {
 			if !info.showInHelp() {
 				continue


### PR DESCRIPTION
The panic is caused by calling strings.Repeat() with negative repeat count. This
is triggered by incorrectly computed alignment info.

Since the positional arguments are always shown (even when the subcommand is
hidden), the arguments need to be accounted for when calculating alignment.

The panic backtrace is the following:

```
--- FAIL: TestHiddenCommandNoBuiltinHelp (0.00s)
panic: strings: negative Repeat count [recovered]
        panic: strings: negative Repeat count

goroutine 91 [running]:
testing.tRunner.func1.1(0x57f160, 0x5f3f20)
        /home/maciek/code/go/go/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc000252a80)
        /home/maciek/code/go/go/src/testing/testing.go:1075 +0x41a
panic(0x57f160, 0x5f3f20)
        /home/maciek/code/go/go/src/runtime/panic.go:969 +0x1b9
strings.Repeat(0x5bc3b0, 0x1, 0xfffffffffffffff1, 0x13, 0x0)
        /home/maciek/code/go/go/src/strings/strings.go:529 +0x5e5
github.com/jessevdk/go-flags.(*Parser).WriteHelp(0xc000387340, 0x5f6d40, 0xc0002772f0)
        /home/maciek/work/canonical/workspace/src/github.com/jessevdk/go-flags/help.go:449 +0x510
github.com/jessevdk/go-flags.TestHiddenCommandNoBuiltinHelp(0xc000252a80)
        /home/maciek/work/canonical/workspace/src/github.com/jessevdk/go-flags/help_test.go:469 +0x4d4
testing.tRunner(0xc000252a80, 0x5cd9a0)
        /home/maciek/code/go/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
        /home/maciek/code/go/go/src/testing/testing.go:1168 +0x2b3
exit status 2
FAIL    github.com/jessevdk/go-flags    0.016s
```

There's also an open question whether positional arguments should be listed in the help output.

