### PR TITLE
feature: Enable compiling on AIX

### DIFF
--- a/termsize.go
+++ b/termsize.go
@@ -1,4 +1,4 @@
-// +build !windows,!plan9,!appengine,!wasm
+// +build !windows,!plan9,!appengine,!wasm,!aix
 
 package flags
 

--- a/termsize_nosysioctl.go
+++ b/termsize_nosysioctl.go
@@ -1,4 +1,4 @@
-// +build plan9 appengine wasm
+// +build plan9 appengine wasm aix
 
 package flags
 


### PR DESCRIPTION
Small&obvious change to enable compilation on AIX. 

Without the patch:

```
$ GOOS=aix GOARCH=ppc64 go build -o rice.aix
# github.com/jessevdk/go-flags
../../../../../pkg/mod/github.com/jessevdk/go-flags@v1.4.0/termsize.go:19:19: undefined: syscall.SYS_IOCTL
```

With the patch:

```
$ GOOS=aix GOARCH=ppc64 go build -o rice.aix && echo OK
OK
```