### PR TITLE
Revert invalid example

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/jessevdk/go-flags"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type EditorOptions struct {
@@ -70,13 +71,9 @@ var parser = flags.NewParser(&options, flags.Default)
 
 func main() {
 	if _, err := parser.Parse(); err != nil {
-		switch flagsErr := err.(type) {
-		case flags.ErrorType:
-			if flagsErr == flags.ErrHelp {
-				os.Exit(0)
-			}
-			os.Exit(1)
-		default:
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			os.Exit(0)
+		} else {
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
#319 modified the example code which shows how to exit with code 0 when --help option is provided.

```go
if _, err := parser.Parse(); err != nil {
	switch flagsErr := err.(type) {
	case flags.ErrorType:
		if flagsErr == flags.ErrHelp {
			os.Exit(0)
		}
		os.Exit(1)
	default:
		os.Exit(1)
	}
}
```

But actually the change was invalid. `err.(type)` is an `*flags.Error`, not an `flags.ErrorType`.

Therefore, the code exits with code 1 even when --help option is provided.

It seems like the [original example code](https://github.com/jessevdk/go-flags/commit/8bc97d602c3bfeb5fc6fc9b5a9c898f245495637#diff-7c1b8c5172fe7687c2af90f55f18e7e5eacf13af953ccc2bbeb5de3fa56e2688) before #319 was valid. So this PR reverts the example.


