### PR TITLE
Add support for SOURCE_DATE_EPOCH for TestMan

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -229,6 +230,14 @@ func TestMan(t *testing.T) {
 	got := buf.String()
 
 	tt := time.Now()
+	source_date_epoch := os.Getenv("SOURCE_DATE_EPOCH")
+	if source_date_epoch != "" {
+		sde, err := strconv.ParseInt(source_date_epoch, 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("Invalid SOURCE_DATE_EPOCH: %s", err))
+		}
+		tt = time.Unix(sde, 0)
+	}
 
 	var envDefaultName string
 


### PR DESCRIPTION
This stems from of Marina Moore’s (@mnm678) excellent work on adding SOURCE_DATE_EPOCH for reproducible builds in PR #285, and has been extended by Jelmer Vernooĳ (@jelmer) such that TestMan in help_test.go would not fail when SOURCE_DATE_EPOCH is set to a date different from today, e.g.:

```console
$ SOURCE_DATE_EPOCH=1630000000 go test ./...
--- FAIL: TestMan (0.00s)
    assert_test.go:42: assert_test.go:177: Unexpected man page:
        
        --- got
        +++ expected
        @@ -1,4 +1,4 @@
        -.TH TestMan 1 "26 August 2021"
        +.TH TestMan 1 "2 December 2021"
         .SH NAME
         TestMan \- Test manpage generation
         .SH SYNOPSIS
FAIL
FAIL	github.com/jessevdk/go-flags	0.020s
?   	github.com/jessevdk/go-flags/examples	[no test files]
FAIL
```

I became aware of this issue when this failed test was reported by Lucas Nussbaum (@lnussbaum) for the golang-github-itchyny-go-flags package (https://github.com/itchyny/go-flags fork) in [Debian Bug#997553](https://bugs.debian.org/997553).

Reference:
* https://salsa.debian.org/go-team/packages/golang-go-flags/-/merge_requests/1
* https://salsa.debian.org/go-team/packages/golang-go-flags/-/commit/3f11c5378d8d3778fbd6b249d6dd26e4785fd7ac