### PR TITLE
Fix single choice support

### DIFF
--- a/option.go
+++ b/option.go
@@ -261,10 +261,12 @@ func (option *Option) Set(value *string) error {
 		}
 
 		if !found {
-			allowed := strings.Join(option.Choices[0:len(option.Choices)-1], ", ")
-
+			var allowed string
 			if len(option.Choices) > 1 {
+				allowed = strings.Join(option.Choices[0:len(option.Choices)-1], ", ")
 				allowed += " or " + option.Choices[len(option.Choices)-1]
+			} else {
+				allowed = option.Choices[0]
 			}
 
 			return newErrorf(ErrInvalidChoice,


### PR DESCRIPTION
This PR fixes a situation when there is only once choice available. Normally, we probably wouldn't expect it. But it can be in a situation where the software is being actively developed and some feature is being added with future possible extension. Thus giving a single option could be a valid situation. 

Currently, if you pass an incorrect option to a single-optioned parameter, you will get an error with an empty list of possible values: `Allowed values are: `. This PR adds that single value to the list.

In addition, this PR adds some tests and fixes broken tests as well (if you think the fix for the broken tests is excessive, I can remove it).