### PR TITLE
Update to run go-flags on AIX

### DIFF
--- a/termsize.go
+++ b/termsize.go
@@ -1,4 +1,4 @@
-// +build !windows,!plan9,!appengine,!wasm
+// +build !windows,!plan9,!appengine,!wasm,!aix
 
 package flags
 

--- a/termsize_nosysioctl.go
+++ b/termsize_nosysioctl.go
@@ -1,4 +1,4 @@
-// +build plan9 appengine wasm
+// +build plan9 appengine wasm aix
 
 package flags
 


### PR DESCRIPTION
I tried to build the datadog-agent for AIX, and I had difficulties because it didn't build the agent for AIX. Your library is used by datadog-agent, which is why I encountered this problem.