### PR TITLE
Support per-command PassAfterNonOption

### DIFF
--- a/command.go
+++ b/command.go
@@ -30,6 +30,12 @@ type Command struct {
 	// Whether positional arguments are required
 	ArgsRequired bool
 
+	// Whether to pass all arguments after the first non option as remaining
+	// command line arguments. This is equivalent to strict POSIX processing.
+	// This is command-local version of PassAfterNonOption Parser flag. It
+	// cannot be turned off when PassAfterNonOption Parser flag is set.
+	PassAfterNonOption bool
+
 	commands            []*Command
 	hasBuiltinHelpGroup bool
 	args                []*Arg
@@ -244,6 +250,7 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 			longDescription := mtag.Get("long-description")
 			subcommandsOptional := mtag.Get("subcommands-optional")
 			aliases := mtag.GetMany("alias")
+			passAfterNonOption := mtag.Get("pass-after-non-option")
 
 			subc, err := c.AddCommand(subcommand, shortDescription, longDescription, ptrval.Interface())
 
@@ -259,6 +266,10 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 
 			if len(aliases) > 0 {
 				subc.Aliases = aliases
+			}
+
+			if len(passAfterNonOption) > 0 {
+				subc.PassAfterNonOption = true
 			}
 
 			return true, nil

--- a/parser.go
+++ b/parser.go
@@ -252,7 +252,7 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 		}
 
 		if !argumentIsOption(arg) {
-			if (p.Options&PassAfterNonOption) != None && s.lookup.commands[arg] == nil {
+			if ((p.Options&PassAfterNonOption) != None || s.command.PassAfterNonOption) && s.lookup.commands[arg] == nil {
 				// If PassAfterNonOption is set then all remaining arguments
 				// are considered positional
 				if err = s.addArgs(s.arg); err != nil {


### PR DESCRIPTION
Currently, PassAfterNonOption is a Parser flag. This means that it
applies to all commands. Sometimes it's desirable have this behavior on
only a subset of commands. For instance, for restart subcommand, we
would like the default behavior of parsing both -v and --wait flags:

  mycmd restart -v foo bar --wait

But for exec subcommand, we want only the -v flag to be parsed. The -l
flag should be treated as positional argument.

  mycmd exec -v ls -l /

Introduce PassAfterNonOption boolean field in Command structure that has
the same meaning as the flag in Parser but applies only to the currently
active command. The field can be set by adding pass-after-non-option tag
to data structure declaration.

This only allows to selectively enable the behavior in commands when
PassAfterNonOption Parser flag is unset. When the flag is set, the
behavior is enabled for all commands and cannot be disabled by false
value of PassAfterNonOption field. This is to keep the code simple and
backwards compatible (since PassAfterNonOption field defaults to false).