### PR TITLE
feat: Support terminated options like ``find -exec``

### DIFF
--- a/group.go
+++ b/group.go
@@ -285,6 +285,8 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		choices := mtag.GetMany("choice")
 		hidden := !isStringFalsy(mtag.Get("hidden"))
 
+		terminator := mtag.Get("terminator")
+
 		option := &Option{
 			Description:      description,
 			ShortName:        short,
@@ -299,6 +301,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			DefaultMask:      defaultMask,
 			Choices:          choices,
 			Hidden:           hidden,
+			Terminator:       terminator,
 
 			group: g,
 
@@ -311,6 +314,13 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			return newErrorf(ErrInvalidTag,
 				"boolean flag `%s' may not have default values, they always default to `false' and can only be turned on",
 				option.shortAndLongName())
+		}
+
+		if option.isTerminated() && option.value.Type() != reflect.TypeOf((*[][]string)(nil)).Elem() {
+			return newErrorf(ErrInvalidTag,
+				"field representing flag `%s' may not have any `terminator' tag while being of type %s",
+				option.shortAndLongName(),
+				option.value.Type())
 		}
 
 		g.options = append(g.options, option)

--- a/options_test.go
+++ b/options_test.go
@@ -141,3 +141,87 @@ func TestPassAfterNonOptionWithPositionalIntFail(t *testing.T) {
 		assertStringArray(t, ret, test.ret)
 	}
 }
+
+func TestTerminatedOptions(t *testing.T) {
+	type testOpt struct {
+		Args    [][]string `short:"a" long:"args" terminator:";"`
+		Verbose bool       `short:"v"`
+		Mode    int        `short:"m"`
+	}
+
+	tests := []struct {
+		parserOpts Options
+		args       []string
+		_Args      [][]string
+		_Verbose   bool
+		_Mode      int
+		ret        []string
+		shouldErr  bool
+	}{
+		{
+			args: []string{
+				"--args", "bin", "-xyz", "--foo=bar", "-m", "5", "-v", "foo bar", ";",
+				"-v",
+				"--args=", "--no-delim",
+			},
+			_Args: [][]string{
+				{"bin", "-xyz", "--foo=bar", "-m", "5", "-v", "foo bar"},
+				{"--no-delim"},
+			},
+			_Verbose: true,
+		},
+		{
+			args:  []string{"--args", "--foo", "bar;", "-v"},
+			_Args: [][]string{{"--foo", "bar;", "-v"}},
+		},
+		{
+			args:  []string{"--args", "foo\tbar", "\"x y z\""},
+			_Args: [][]string{{"foo\tbar", "\"x y z\""}},
+		},
+		{
+			parserOpts: PassDoubleDash,
+			args:       []string{"--args", "--foo", "--", "bar", ";", "-m", "1", "--", "-v"},
+			_Args:      [][]string{{"--foo", "--", "bar"}},
+			_Mode:      1,
+			ret:        []string{"-v"},
+		},
+		{
+			args:     []string{"-va", "-m", "5"},
+			_Args:    [][]string{{"-m", "5"}},
+			_Verbose: true,
+		},
+	}
+
+	for _, test := range tests {
+		opts := testOpt{}
+		p := NewParser(&opts, test.parserOpts)
+		ret, err := p.ParseArgs(test.args)
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Fatalf("Unexpected error: %v", err)
+			} else {
+				continue
+			}
+		} else if test.shouldErr {
+			t.Fatalf("Expected error")
+		}
+
+		if opts.Verbose != test._Verbose {
+			t.Errorf("Expected Verbose to be %v, found %v", test._Verbose, opts.Verbose)
+		}
+
+		if opts.Mode != test._Mode {
+			t.Errorf("Expected Mode to be %v, found %v", test._Mode, opts.Mode)
+		}
+
+		if len(opts.Args) != len(test._Args) {
+			t.Errorf("Expected Args to be %v, found %v", test._Args, opts.Args)
+		}
+		for i := 0; i < len(opts.Args); i++ {
+			assertStringArray(t, opts.Args[i], test._Args[i])
+		}
+
+		assertStringArray(t, ret, test.ret)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -526,6 +526,19 @@ func (p *Parser) parseOption(s *parseState, name string, option *Option, canarg 
 		}
 
 		err = option.Set(nil)
+	} else if option.isTerminated() {
+		args := make([]string, 0)
+		if argument != nil && *argument != "" {
+			args = append(args, *argument)
+		}
+		for !s.eof() {
+			arg := s.pop()
+			if option.foundTerminator(arg) {
+				break
+			}
+			args = append(args, arg)
+		}
+		err = option.SetTerminatedOption(args)
 	} else if argument != nil || (canarg && !s.eof()) {
 		var arg string
 


### PR DESCRIPTION
feat: Support terminated options like ``find -exec``

Enable option to receive arguments until specified terminator
is reached or EOL has been found. This is inspired from
``find -exec [commands..] ;`` where commands.. is treated as
arguments to -exec.

If for an option ``opt``, ``terminator`` is specified to be
; (semi-colon), in the following

    ./<binary> cmd [options..] --opt a --b=c -- -d "x y" ; [options..]

--opt will receive {"a", "--b=c", "--", "-d", "x y"} as its
argument. Note that, the -- inside will also be passed to
--opt regardless PassDoubleDash is set or not. However,
once the scope of --opt is finished, i.e. terminator ;
is reached, -- will act as before if PassDoubleDash is set.

Use tag ``terminator`` to specify the terminator for
the option related to that field.

Please note that, the specified terminator should be a
separate token, instead of being jotted with other characters.
For example,
    --opt [arguments..] ; [options..]
will be correctly parsed with terminator: ";". However,
    --opt [arguments..] arg; [options..]
will not be correctly parsed. The parser will pass "arg;",
and continue to look for the terminator in [options..].

Currently, the field related to the terminated option
--opt can only have ``[][]string`` value type. For example,
    --opt a b ; [options..] --opt c d ; [options..]
will be parsed as [][]string{ {"a", "b"}, {"c", "d"} }.
There should be support for ``[]string`` fields soon.
