### PR TITLE
Fix multiple short options with `IgnoreUnknown` option

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -629,6 +629,8 @@ func (p *Parser) parseShort(s *parseState, optname string, argument *string) err
 		optname, argument = p.splitShortConcatArg(s, optname)
 	}
 
+	var err error
+
 	for i, c := range optname {
 		shortname := string(c)
 
@@ -641,7 +643,7 @@ func (p *Parser) parseShort(s *parseState, optname string, argument *string) err
 				return err
 			}
 		} else {
-			return newErrorf(ErrUnknownFlag, "unknown flag `%s'", shortname)
+			err = newErrorf(ErrUnknownFlag, "unknown flag `%s'", shortname)
 		}
 
 		// Only the first option can have a concatted argument, so just
@@ -649,7 +651,7 @@ func (p *Parser) parseShort(s *parseState, optname string, argument *string) err
 		argument = nil
 	}
 
-	return nil
+	return err
 }
 
 func (p *parseState) addArgs(args ...string) error {

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -64,3 +64,27 @@ func TestIgnoreUnknownFlags(t *testing.T) {
 		t.Fatalf("Expected %v but got %v", exargs, args)
 	}
 }
+
+func TestUnknownFlagsStacked(t *testing.T) {
+	var opts = struct {
+		First  bool `short:"f" long:"first"`
+		Second bool `short:"s" long:"second"`
+	}{}
+
+	args := []string{"-afs"}
+
+	p := NewParser(&opts, IgnoreUnknown)
+	args, err := p.ParseArgs(args)
+
+	if !opts.First {
+		t.Fatal("First arguement not recognized")
+	}
+
+	if !opts.Second {
+		t.Fatal("Second arguement not recognized")
+	}
+
+	if err != nil {
+		t.Fatal("Expected error for unknown argument")
+	}
+}

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -65,16 +65,20 @@ func TestIgnoreUnknownFlags(t *testing.T) {
 	}
 }
 
-func TestUnknownFlagsStacked(t *testing.T) {
+func TestIgnoreUnknownStacked(t *testing.T) {
 	var opts = struct {
 		First  bool `short:"f" long:"first"`
 		Second bool `short:"s" long:"second"`
 	}{}
 
-	args := []string{"-afs"}
+	args := []string{"-fas"}
 
 	p := NewParser(&opts, IgnoreUnknown)
 	args, err := p.ParseArgs(args)
+
+	exargs := []string{
+		"-fas",
+	}
 
 	if !opts.First {
 		t.Fatal("First arguement not recognized")
@@ -85,6 +89,21 @@ func TestUnknownFlagsStacked(t *testing.T) {
 	}
 
 	if err != nil {
-		t.Fatal("Expected error for unknown argument")
+		t.Fatal("Should not receive an error")
+	}
+
+	issame := (len(args) == len(exargs))
+
+	if issame {
+		for i := 0; i < len(args); i++ {
+			if args[i] != exargs[i] {
+				issame = false
+				break
+			}
+		}
+	}
+
+	if !issame {
+		t.Fatalf("Expected %v but got %v", exargs, args)
 	}
 }


### PR DESCRIPTION
Related to [Issue](https://github.com/jessevdk/go-flags/issues/399):

Stacked short options are not recognized after first unknown option (even with flag `IgnoreUnknown`).

Following code sample:

```go
package main

import (
	"fmt"

	"github.com/jessevdk/go-flags"
)

var first struct {
	Query bool `short:"Q" long:"query"`
}

var second struct {
	Quick bool `short:"q" long:"quick"`
}

func main() {
	flags.NewParser(&first, flags.IgnoreUnknown).Parse()
	fmt.Println(first)

	flags.NewParser(&second, flags.IgnoreUnknown).Parse()
	fmt.Println(second)
}

```


Before fix:

```sh
 > go run . -Qq
{true}
{false}
 > go run . -qQ  
{false}
{true}
 > go run . -Q -q
{true}
{true}
```

After fix:

```sh
 > go run . -Qq
{true}
{true}
 > go run . -qQ  
{true}
{true}
 > go run . -Q -q
{true}
{true}
```
