### PR TITLE
Undersocre support for numbers (set default base for strconv.Parse* to 0)

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -224,7 +224,7 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 			retval.SetBool(b)
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		base, err := getBase(options, 10)
+		base, err := getBase(options, 0)
 
 		if err != nil {
 			return err
@@ -238,7 +238,7 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 
 		retval.SetInt(parsed)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		base, err := getBase(options, 10)
+		base, err := getBase(options, 0)
 
 		if err != nil {
 			return err

--- a/parser_test.go
+++ b/parser_test.go
@@ -13,11 +13,13 @@ import (
 )
 
 type defaultOptions struct {
-	Int        int `long:"i"`
-	IntDefault int `long:"id" default:"1"`
+	Int           int `long:"i"`
+	IntDefault    int `long:"id" default:"1"`
+	IntUnderscore int `long:"idu" default:"1_0"`
 
-	Float64        float64 `long:"f"`
-	Float64Default float64 `long:"fd" default:"-3.14"`
+	Float64           float64 `long:"f"`
+	Float64Default    float64 `long:"fd" default:"-3.14"`
+	Float64Underscore float64 `long:"fdu" default:"-3_3.14"`
 
 	NumericFlag bool `short:"3"`
 
@@ -45,11 +47,13 @@ func TestDefaults(t *testing.T) {
 			msg:  "no arguments, expecting default values",
 			args: []string{},
 			expected: defaultOptions{
-				Int:        0,
-				IntDefault: 1,
+				Int:           0,
+				IntDefault:    1,
+				IntUnderscore: 10,
 
-				Float64:        0.0,
-				Float64Default: -3.14,
+				Float64:           0.0,
+				Float64Default:    -3.14,
+				Float64Underscore: -33.14,
 
 				NumericFlag: false,
 
@@ -68,13 +72,15 @@ func TestDefaults(t *testing.T) {
 		},
 		{
 			msg:  "non-zero value arguments, expecting overwritten arguments",
-			args: []string{"--i=3", "--id=3", "--f=-2.71", "--fd=2.71", "-3", "--str=def", "--strd=def", "--t=3ms", "--td=3ms", "--m=c:3", "--md=c:3", "--s=3", "--sd=3"},
+			args: []string{"--i=3", "--id=3", "--idu=3_3", "--f=-2.71", "--fd=2.71", "--fdu=2_2.71", "-3", "--str=def", "--strd=def", "--t=3ms", "--td=3ms", "--m=c:3", "--md=c:3", "--s=3", "--sd=3"},
 			expected: defaultOptions{
-				Int:        3,
-				IntDefault: 3,
+				Int:           3,
+				IntDefault:    3,
+				IntUnderscore: 33,
 
-				Float64:        -2.71,
-				Float64Default: 2.71,
+				Float64:           -2.71,
+				Float64Default:    2.71,
+				Float64Underscore: 22.71,
 
 				NumericFlag: true,
 
@@ -93,13 +99,15 @@ func TestDefaults(t *testing.T) {
 		},
 		{
 			msg:  "zero value arguments, expecting overwritten arguments",
-			args: []string{"--i=0", "--id=0", "--f=0", "--fd=0", "--str", "", "--strd=\"\"", "--t=0ms", "--td=0s", "--m=:0", "--md=:0", "--s=0", "--sd=0"},
+			args: []string{"--i=0", "--id=0", "--idu=0", "--f=0", "--fd=0", "--fdu=0", "--str", "", "--strd=\"\"", "--t=0ms", "--td=0s", "--m=:0", "--md=:0", "--s=0", "--sd=0"},
 			expected: defaultOptions{
-				Int:        0,
-				IntDefault: 0,
+				Int:           0,
+				IntDefault:    0,
+				IntUnderscore: 0,
 
-				Float64:        0,
-				Float64Default: 0,
+				Float64:           0,
+				Float64Default:    0,
+				Float64Underscore: 0,
 
 				String:        "",
 				StringDefault: "",


### PR DESCRIPTION
Hello, dear @jessevdk! Thank you very much for the library you've built, I'm using it a lot and I enjoy it.

I want to suggest a little improvement for numbers parsing.

Default values in annotations are sometimes quite big, and it would be great to support settings them with underscores like this:
```
MaxRetries int `long:"max-retries" default:"3_000"`
```
Default library has support for underscores, but it's a bit vague, you need to set the base to 0. That'll also lead to auto-detecting of the base, which is also nice.

An alternative option is to use `strings.ReplaceAll(s, "_", "")` which will work, but I prefer to rely on the standard library.

Looking forward to knowing what you think, feel free to request any changes or to make changes yourself.