### PR TITLE
feat: support field tag prefix and custom field tag names

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func expectConvert(t *testing.T, o *Option, expected string) {
-	s, err := convertToString(o.value, o.tag)
+	s, err := convertToString(o.value, o.tag, NewFlagTags())
 
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -129,7 +129,7 @@ func TestConvertToStringInvalidIntBase(t *testing.T) {
 	grp, _ := p.AddGroup("test group", "", &opts)
 	o := grp.Options()[0]
 
-	_, err := convertToString(o.value, o.tag)
+	_, err := convertToString(o.value, o.tag, NewFlagTags())
 
 	if err != nil {
 		err = newErrorf(ErrMarshal, "%v", err)
@@ -149,7 +149,7 @@ func TestConvertToStringInvalidUintBase(t *testing.T) {
 	grp, _ := p.AddGroup("test group", "", &opts)
 	o := grp.Options()[0]
 
-	_, err := convertToString(o.value, o.tag)
+	_, err := convertToString(o.value, o.tag, NewFlagTags())
 
 	if err != nil {
 		err = newErrorf(ErrMarshal, "%v", err)
@@ -167,7 +167,7 @@ func TestConvertToMapWithDelimiter(t *testing.T) {
 	grp, _ := p.AddGroup("test group", "", &opts)
 	o := grp.Options()[0]
 
-	err := convert("key=value", o.value, o.tag)
+	err := convert("key=value", o.value, o.tag, NewFlagTags())
 
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/flags.go
+++ b/flags.go
@@ -255,3 +255,108 @@ allowing simple filename completion. A slice or array argument value
 whose element type implements flags.Completer will also be completed.
 */
 package flags
+
+const (
+	FlagTagShort               = "short"
+	FlagTagLong                = "long"
+	FlagTagRequired            = "required"
+	FlagTagDescription         = "description"
+	FlagTagLongDescription     = "long-description"
+	FlagTagNoFlag              = "no-flag"
+	FlagTagOptional            = "optional"
+	FlagTagOptionalValue       = "optional-value"
+	FlagTagDefault             = "default"
+	FlagTagDefaultMask         = "default-mask"
+	FlagTagEnv                 = "env"
+	FlagTagEnvDelim            = "env-delim"
+	FlagTagValueName           = "value-name"
+	FlagTagChoice              = "choice"
+	FlagTagHidden              = "hidden"
+	FlagTagBase                = "base"
+	FlagTagIniName             = "ini-name"
+	FlagTagNoIni               = "no-ini"
+	FlagTagGroup               = "group"
+	FlagTagNamespace           = "namespace"
+	FlagTagEnvNamespace        = "env-namespace"
+	FlagTagCommand             = "command"
+	FlagTagSubCommandsOptional = "subcommands-optional"
+	FlagTagAlias               = "alias"
+	FlagTagPositionalArgs      = "positional-args"
+	FlagTagPositionalArgName   = "positional-arg-name"
+	FlagTagKeyValueDelimiter   = "key-value-delimiter"
+	FlagTagPassAfterNonOption  = "pass-after-non-option"
+	FlagTagUnquote             = "unquote"
+	FlagTagReadIniName         = "_read-ini-name"
+)
+
+type FlagTags struct {
+	Short               string
+	Long                string
+	Required            string
+	Description         string
+	LongDescription     string
+	NoFlag              string
+	Optional            string
+	OptionalValue       string
+	Default             string
+	DefaultMask         string
+	Env                 string
+	EnvDelim            string
+	ValueName           string
+	Choice              string
+	Hidden              string
+	Base                string
+	IniName             string
+	NoIni               string
+	Group               string
+	Namespace           string
+	EnvNamespace        string
+	Command             string
+	SubCommandsOptional string
+	Alias               string
+	PositionalArgs      string
+	PositionalArgName   string
+	KeyValueDelimiter   string
+	PassAfterNonOption  string
+	Unquote             string
+	ReadIniName         string
+}
+
+func NewFlagTags() *FlagTags {
+	return NewFlagTagsWithPrefix("")
+}
+
+func NewFlagTagsWithPrefix(prefix string) *FlagTags {
+	return &FlagTags{
+		Short:               prefix + FlagTagShort,
+		Long:                prefix + FlagTagLong,
+		Required:            prefix + FlagTagRequired,
+		Description:         prefix + FlagTagDescription,
+		LongDescription:     prefix + FlagTagLongDescription,
+		NoFlag:              prefix + FlagTagNoFlag,
+		Optional:            prefix + FlagTagOptional,
+		OptionalValue:       prefix + FlagTagOptionalValue,
+		Default:             prefix + FlagTagDefault,
+		DefaultMask:         prefix + FlagTagDefaultMask,
+		Env:                 prefix + FlagTagEnv,
+		EnvDelim:            prefix + FlagTagEnvDelim,
+		ValueName:           prefix + FlagTagValueName,
+		Choice:              prefix + FlagTagChoice,
+		Hidden:              prefix + FlagTagHidden,
+		Base:                prefix + FlagTagBase,
+		IniName:             prefix + FlagTagIniName,
+		NoIni:               prefix + FlagTagNoIni,
+		Group:               prefix + FlagTagGroup,
+		Namespace:           prefix + FlagTagNamespace,
+		EnvNamespace:        prefix + FlagTagEnvNamespace,
+		Command:             prefix + FlagTagCommand,
+		SubCommandsOptional: prefix + FlagTagSubCommandsOptional,
+		Alias:               prefix + FlagTagAlias,
+		PositionalArgs:      prefix + FlagTagPositionalArgs,
+		PositionalArgName:   prefix + FlagTagPositionalArgName,
+		KeyValueDelimiter:   prefix + FlagTagKeyValueDelimiter,
+		PassAfterNonOption:  prefix + FlagTagPassAfterNonOption,
+		Unquote:             prefix + FlagTagUnquote,
+		ReadIniName:         prefix + FlagTagReadIniName,
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -113,7 +113,7 @@ func TestMarshalError(t *testing.T) {
 	p := NewParser(&opts, Default)
 	o := p.Command.Groups()[0].Options()[0]
 
-	_, err := convertToString(o.value, o.tag)
+	_, err := convertToString(o.value, o.tag, NewFlagTags())
 
 	assertError(t, err, ErrMarshal, "Failed to marshal")
 }

--- a/option.go
+++ b/option.go
@@ -276,10 +276,10 @@ func (option *Option) Set(value *string) error {
 	if option.isFunc() {
 		return option.call(value)
 	} else if value != nil {
-		return convert(*value, option.value, option.tag)
+		return convert(*value, option.value, option.tag, option.group.flagTags)
 	}
 
-	return convert("", option.value, option.tag)
+	return convert("", option.value, option.tag, option.group.flagTags)
 }
 
 func (option *Option) setDefault(value *string) error {
@@ -384,7 +384,7 @@ func (option *Option) valueIsDefault() bool {
 
 	if len(option.Default) != 0 {
 		for _, v := range option.Default {
-			convert(v, checkval, option.tag)
+			convert(v, checkval, option.tag, option.group.flagTags)
 		}
 	}
 
@@ -486,7 +486,7 @@ func (option *Option) call(value *string) error {
 		val := reflect.New(tp)
 		val = reflect.Indirect(val)
 
-		if err := convert(*value, val, option.tag); err != nil {
+		if err := convert(*value, val, option.tag, option.group.flagTags); err != nil {
 			return err
 		}
 
@@ -524,7 +524,7 @@ func (option *Option) updateDefaultLiteral() {
 		}
 
 		if showdef {
-			def, _ = convertToString(option.value, option.tag)
+			def, _ = convertToString(option.value, option.tag, option.group.flagTags)
 		}
 	} else if len(defs) != 0 {
 		l := len(defs) - 1

--- a/optstyle_other.go
+++ b/optstyle_other.go
@@ -61,7 +61,7 @@ func (c *Command) addHelpGroup(showHelp func() error) *Group {
 	}
 
 	help.ShowHelp = showHelp
-	ret, _ := c.AddGroup("Help Options", "", &help)
+	ret, _ := c.AddGroupWithCustomFlagTags("Help Options", "", &help, NewFlagTags())
 	ret.isBuiltinHelp = true
 
 	return ret


### PR DESCRIPTION
To avoid tag conflicts with other third-party libraries like [env](https://github.com/caarlos0/env)

1. support field tag prefix
```go
type Cfg struct {
    Path string `flag-short:"p" flag-long:"path" flag-description:"path to xxx"`
}

cfg := &Cfg{}
parser := flags.NewParser(cfg, flags.Default, flags.FlagTagPrefix("flag-"))
parser.Parse()
```
2. support custom field tags name
```go
type Cfg struct {
    Path string `flag-custom-short:"p" long:"path" description:"path to xxx"`
}

flagTags := flags.NewFlagTags()
flagTags.Short = "flag-custom-short"
cfg := &Cfg{}
parser := flags.NewParser(cfg, flags.Default, flags.CustomFlagTags(flagTags))
parser.Parse()
```