### PR TITLE
add zsh-completion example

### DIFF
--- a/examples/zsh-completion
+++ b/examples/zsh-completion
@@ -1,0 +1,17 @@
+#compdef examples
+compdef _examples examples
+
+_examples() {
+  local IFS=$'\n'
+  local -a completions
+  completions=($(GO_FLAGS_COMPLETION=1 "${words[@]}"))
+  if [[ -n "$completions" ]]; then
+    _describe 'command' completions
+  fi
+	return 1
+}
+
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_examples" ]; then
+    _examples "$@"
+fi


### PR DESCRIPTION
There is currently no working zsh-completion example. It took me a while to figure this out, so I wanted to commit it back to the repo for others. Especially since this has been requested previously.

Sovles issue: https://github.com/jessevdk/go-flags/issues/374