### PR TITLE
WIP: Allow setting and reseting bool values via standard arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Supported features:
 * Options with short names (-v)
 * Options with long names (--verbose)
 * Options with and without arguments (bool v.s. other type)
+* Long boolean options with --enable-* and --disable-* syntax
+* Long boolean options with --no-* syntax
 * Options with optional arguments and default values
 * Multiple option groups each containing a set of options
 * Generate and print well-formatted help message
@@ -57,6 +59,16 @@ var opts struct {
 
 	// Example of a callback, called each time the option is found.
 	Call func(string) `short:"c" description:"Call phone number"`
+
+	// Example of a boolean flag which can be disabled by using "--no-debug"
+	Debug bool `long:"debug" default:"true" disable-type:"no"`
+
+    // Example of a boolean flag which can be disabled by using "--d=false"
+    Color bool `short:"c" disable-type:"value"`
+
+	// Example of a boolean flag which can be enabled  by using "--enable-fast-dns"
+	FastDns bool `long:"fast-dns" disable-type:"value"`
+
 
 	// Example of a required flag
 	Name string `short:"n" long:"name" description:"A name" required:"true"`

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ var opts struct {
 	// Example of a boolean flag which can be disabled by using "--no-debug"
 	Debug bool `long:"debug" default:"true" disable-type:"no"`
 
-    // Example of a boolean flag which can be disabled by using "--d=false"
-    Color bool `short:"c" disable-type:"value"`
+	// Example of a boolean flag which can be disabled by using "--d=false"
+	Color bool `short:"c" disable-type:"value"`
 
 	// Example of a boolean flag which can be enabled  by using "--enable-fast-dns"
 	FastDns bool `long:"fast-dns" disable-type:"value"`

--- a/error.go
+++ b/error.go
@@ -28,7 +28,7 @@ const (
 	ErrHelp
 
 	// ErrNoArgumentForBool indicates that an argument was given for a
-	// boolean flag (which don't not take any arguments).
+	// boolean flag (which do not take any arguments).
 	ErrNoArgumentForBool
 
 	// ErrRequired indicates that a required flag was not provided.

--- a/help_test.go
+++ b/help_test.go
@@ -56,6 +56,14 @@ type helpOptions struct {
 		} `group:"Subsubgroup" namespace:"sap"`
 	} `group:"Subgroup" namespace:"sip"`
 
+	GroupBool struct {
+		SimpleBool bool `short:"b" description:"Bool which supports setting to true only"`
+		LongBool   bool `long:"bool" description:"Bool which supports setting to true only"`
+		ValueBool  bool `short:"V" long:"value" description:"Bool which supports setting value via optional argument" disable-type:"value"`
+		NoBool     bool `short:"n" long:"no" description:"Bool which supports setting value via 'no-' prefix" disable-type:"no"`
+		EnDisBool  bool `short:"e" long:"endis" description:"Bool which supports setting value via 'enable-' and 'disable-' prefix" disable-type:"enable-disable"`
+	} `group:"SimpleBool" namespace:"bool"`
+
 	Bommand struct {
 		Hidden bool `long:"hidden" description:"A hidden option" hidden:"yes"`
 	} `command:"bommand" description:"A command with only hidden options"`
@@ -111,44 +119,61 @@ func TestHelp(t *testing.T) {
   TestHelp [OPTIONS] [filename] [num] hidden-in-help <bommand | command | parent>
 
 Application Options:
-  /v, /verbose                              Show verbose debug information
-  /c:                                       Call phone number
-      /ptrslice:                            A slice of pointers to string
+  /v, /verbose                                    Show verbose debug information
+  /c:                                             Call phone number
+      /ptrslice:                                  A slice of pointers to string
       /empty-description
-      /default:                             Test default value (default:
-                                            "Some\nvalue")
-      /default-array:                       Test default array value (default:
-                                            Some value, "Other\tvalue")
-      /default-map:                         Testdefault map value (default:
-                                            some:value, another:value)
-      /env-default1:                        Test env-default1 value (default:
-                                            Some value) [%ENV_DEFAULT%]
-      /env-default2:                        Test env-default2 value
-                                            [%ENV_DEFAULT%]
-      /opt-with-arg-name:something          Option with named argument
-      /opt-with-choices:choice[dog|cat]     Option with choices
+      /default:                                   Test default value (default:
+                                                  "Some\nvalue")
+      /default-array:                             Test default array value
+                                                  (default: Some value,
+                                                  "Other\tvalue")
+      /default-map:                               Testdefault map value
+                                                  (default: some:value,
+                                                  another:value)
+      /env-default1:                              Test env-default1 value 
+                                                  (default: Some value)
+                                                  [%ENV_DEFAULT%]
+      /env-default2:                              Test env-default2 value
+                                                  [%ENV_DEFAULT%]
+      /opt-with-arg-name:something                Option with named argument
+      /opt-with-choices:choice[dog|cat]           Option with choices
 
 Other Options:
-  /s:                                       A slice of strings (default: some,
-                                            value)
-      /intmap:                              A map from string to int (default:
-                                            a:1)
+  /s:                                             A slice of strings (default: some,
+                                                  value)
+      /intmap:                                    A map from string to int (default:
+                                                  a:1)
 
 Subgroup:
-      /sip.opt:                             This is a subgroup option
-      /sip.not-hidden-inside-group:         Not hidden inside group
+      /sip.opt:                                   This is a subgroup option
+      /sip.not-hidden-inside-group:               Not hidden inside group
 
 Subsubgroup:
-      /sip.sap.opt:                         This is a subsubgroup option
+      /sip.sap.opt:                               This is a subsubgroup option
+
+SimpleBool:
+  /b                                              Bool which supports setting
+                                                  to true only
+      /bool.bool                                  Bool which supports setting
+                                                  to true only
+  /V, /bool.value:[true|false]                    Bool which supports setting
+                                                  value via optional argument
+  /n, /[no-]bool.no                               Bool which supports setting
+                                                  value via 'no-' prefix
+  /e, /enable-bool.endis, /disable-bool.endis     Bool which supports setting
+                                                  value via 'enable-' and
+                                                  'disable-' prefix
 
 Help Options:
-  /?                                        Show this help message
-  /h, /help                                 Show this help message
+  /?                                              Show this help message
+  /h, /help                                       Show this help message
 
 Arguments:
-  filename:                                 A filename with a long description
-                                            to trigger line wrapping
-  num:                                      A number
+  filename:                                       A filename with a long
+                                                  description to trigger line
+                                                  wrapping
+  num:                                            A number
 
 Available commands:
   bommand  A command with only hidden options
@@ -160,43 +185,60 @@ Available commands:
   TestHelp [OPTIONS] [filename] [num] hidden-in-help <bommand | command | parent>
 
 Application Options:
-  -v, --verbose                             Show verbose debug information
-  -c=                                       Call phone number
-      --ptrslice=                           A slice of pointers to string
+  -v, --verbose                                   Show verbose debug information
+  -c=                                             Call phone number
+      --ptrslice=                                 A slice of pointers to string
       --empty-description
-      --default=                            Test default value (default:
-                                            "Some\nvalue")
-      --default-array=                      Test default array value (default:
-                                            Some value, "Other\tvalue")
-      --default-map=                        Testdefault map value (default:
-                                            some:value, another:value)
-      --env-default1=                       Test env-default1 value (default:
-                                            Some value) [$ENV_DEFAULT]
-      --env-default2=                       Test env-default2 value
-                                            [$ENV_DEFAULT]
-      --opt-with-arg-name=something         Option with named argument
-      --opt-with-choices=choice[dog|cat]    Option with choices
+      --default=                                  Test default value (default:
+                                                  "Some\nvalue")
+      --default-array=                            Test default array value
+                                                  (default: Some value,
+                                                  "Other\tvalue")
+      --default-map=                              Testdefault map value
+                                                  (default: some:value,
+                                                  another:value)
+      --env-default1=                             Test env-default1 value
+                                                  (default: Some value)
+                                                  [$ENV_DEFAULT]
+      --env-default2=                             Test env-default2 value
+                                                  [$ENV_DEFAULT]
+      --opt-with-arg-name=something               Option with named argument
+      --opt-with-choices=choice[dog|cat]          Option with choices
 
 Other Options:
-  -s=                                       A slice of strings (default: some,
-                                            value)
-      --intmap=                             A map from string to int (default:
-                                            a:1)
+  -s=                                             A slice of strings (default:
+                                                  some, value)
+      --intmap=                                   A map from string to int
+                                                  (default: a:1)
 
 Subgroup:
-      --sip.opt=                            This is a subgroup option
-      --sip.not-hidden-inside-group=        Not hidden inside group
+      --sip.opt=                                  This is a subgroup option
+      --sip.not-hidden-inside-group=              Not hidden inside group
 
 Subsubgroup:
-      --sip.sap.opt=                        This is a subsubgroup option
+      --sip.sap.opt=                              This is a subsubgroup option
+
+SimpleBool:
+  -b                                              Bool which supports setting
+                                                  to true only
+      --bool.bool                                 Bool which supports setting
+                                                  to true only
+  -V, --bool.value=[true|false]                   Bool which supports setting
+                                                  value via optional argument
+  -n, --[no-]bool.no                              Bool which supports setting
+                                                  value via 'no-' prefix
+  -e, --enable-bool.endis, --disable-bool.endis   Bool which supports setting
+                                                  value via 'enable-' and
+                                                  'disable-' prefix
 
 Help Options:
-  -h, --help                                Show this help message
+  -h, --help                                      Show this help message
 
 Arguments:
-  filename:                                 A filename with a long description
-                                            to trigger line wrapping
-  num:                                      A number
+  filename:                                       A filename with a long
+                                                  description to trigger line
+                                                  wrapping
+  num:                                            A number
 
 Available commands:
   bommand  A command with only hidden options

--- a/ini_test.go
+++ b/ini_test.go
@@ -100,6 +100,22 @@ NotHiddenInsideGroup =
 ; This is a subsubgroup option
 Opt =
 
+[SimpleBool]
+; Bool which supports setting to true only
+; SimpleBool = false
+
+; Bool which supports setting to true only
+; LongBool = false
+
+; Bool which supports setting value via optional argument
+; ValueBool = false
+
+; Bool which supports setting value via 'no-' prefix
+; NoBool = false
+
+; Bool which supports setting value via 'enable-' and 'disable-' prefix
+; EnDisBool = false
+
 [command]
 ; Use for extra verbosity
 ; ExtraVerbose =
@@ -171,6 +187,22 @@ EnvDefault2 = env-def
 ; This is a subsubgroup option
 ; Opt =
 
+[SimpleBool]
+; Bool which supports setting to true only
+; SimpleBool = false
+
+; Bool which supports setting to true only
+; LongBool = false
+
+; Bool which supports setting value via optional argument
+; ValueBool = false
+
+; Bool which supports setting value via 'no-' prefix
+; NoBool = false
+
+; Bool which supports setting value via 'enable-' and 'disable-' prefix
+; EnDisBool = false
+
 [command]
 ; Use for extra verbosity
 ; ExtraVerbose =
@@ -239,6 +271,22 @@ EnvDefault2 = env-def
 [Subsubgroup]
 ; This is a subsubgroup option
 ; Opt =
+
+[SimpleBool]
+; Bool which supports setting to true only
+; SimpleBool = false
+
+; Bool which supports setting to true only
+; LongBool = false
+
+; Bool which supports setting value via optional argument
+; ValueBool = false
+
+; Bool which supports setting value via 'no-' prefix
+; NoBool = false
+
+; Bool which supports setting value via 'enable-' and 'disable-' prefix
+; EnDisBool = false
 
 [command]
 ; Use for extra verbosity

--- a/option.go
+++ b/option.go
@@ -9,6 +9,13 @@ import (
 	"unicode/utf8"
 )
 
+type DisableBoolFlag string
+
+const DisableTypeNone DisableBoolFlag = ""
+const DisableBoolNo DisableBoolFlag = "no"
+const DisableBoolEnabledDisabled DisableBoolFlag = "enable-disable"
+const DisableBoolValue DisableBoolFlag = "value"
+
 // Option flag information. Contains a description of the option, short and
 // long name as well as a default value and whether an argument for this
 // flag is optional.
@@ -35,6 +42,20 @@ type Option struct {
 
 	// The optional delimiter string for EnvDefaultKey values.
 	EnvDefaultDelim string
+
+	// Available for boolean values only and for long versions only. It specifies
+	// how boolean flag can be disabled. Two common approaches exist and this option
+	// supports both:
+	// - with a "--no-" prefix. E.g. to disable `--debug`, use `--no-debug`
+	// - with either "enable" or "disable", mimicking how a lot of Unix tools work.
+	//   E.g. to enable "foo", long option would be `--enable-foo` and to disable it,
+	//  "--disable-foo".
+	//
+	// To turn on the first option, specify "no".
+	// To turn on the second, specify "enable-disable".
+	//
+	// Empty value assumes no option is specified and this feature is disabled.
+	DisableBool DisableBoolFlag
 
 	// If true, specifies that the argument to an option flag is optional.
 	// When no argument to the flag is specified on the command line, the

--- a/optstyle_other.go
+++ b/optstyle_other.go
@@ -61,7 +61,10 @@ func (c *Command) addHelpGroup(showHelp func() error) *Group {
 	}
 
 	help.ShowHelp = showHelp
-	ret, _ := c.AddGroup("Help Options", "", &help)
+	ret, err := c.AddGroup("Help Options", "", &help)
+	if err != nil {
+		panic(err)
+	}
 	ret.isBuiltinHelp = true
 
 	return ret

--- a/optstyle_windows.go
+++ b/optstyle_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Windows uses a front slash for both short and long options.  Also it uses
-// a colon for name/argument delimter.
+// a colon for name/argument delimiter.
 const (
 	defaultShortOptDelimiter = '/'
 	defaultLongOptDelimiter  = "/"


### PR DESCRIPTION
Hi,

I'm sharing this work-in-progress code to see if this is something you would be willing to merge. So far, most of the code works, but I would need some help with:
- Windows-specific tests, as I do not have a Windows machine (I have fixed them to the best of my knowledge)
- Help with generating man pages

I've also deprecated `AllowBoolValues` since this feature replaces it. In my opinion, this was not really a good place to implement it in the first place. However, I would like to open a discussion about this as well.

Your response is appreciated. Thank you for the great work!

---


This commit enables the developer to allow setting boolean values to `false`. There already was a piece of code which indirectly allowed this, but default could never be true for bools due to #159.

With this patch, a new setting `disable-type` is introduced on boolean options. If unset, the bool variables act as before. However, if set, the user can set (and reset) the bool variable to either `true` or `false`.

The setting has three possible values: `value`. `no` and `enable-disable`.

When the setting is enabled, bool values will behave as follows:

| *`disable-value`* | Syntax                    |
| `value`           | `--bool[=true|false]`     |
| `no`              | `--[no-]bool`             |
| `enable-disable`  | `--[enable|disable]-bool` |

This allows for use cases such as:

```sh
alias program='program --debug`
program --no-debug
```

or

```sh
./program --enable-raytracing --disable-antialiasing
```