### PR TITLE
Add possibility to specify delimiter for slices

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -82,6 +82,20 @@ func assertBoolArray(t *testing.T, a []bool, b []bool) {
 	}
 }
 
+func assertIntArray(t *testing.T, a []int, b []int) {
+	if len(a) != len(b) {
+		assertErrorf(t, "Expected %#v, but got %#v", b, a)
+		return
+	}
+
+	for i, v := range a {
+		if b[i] != v {
+			assertErrorf(t, "Expected %#v, but got %#v", b, a)
+			return
+		}
+	}
+}
+
 func assertParserSuccess(t *testing.T, data interface{}, args ...string) (*Parser, []string) {
 	parser := NewParser(data, Default&^PrintErrors)
 	ret, err := parser.ParseArgs(args)

--- a/convert.go
+++ b/convert.go
@@ -273,9 +273,13 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 			retval.Set(reflect.Append(retval, elemval))
 		} else {
 			s := strings.Split(val, delimiter)
-			out := reflect.MakeSlice(tp, 0, 0)
+			// This creates an empty slice, not a nil
+			out := reflect.MakeSlice(tp, 0, len(s))
 
 			for _, e := range s {
+				if e == "" {
+					continue
+				}
 				if err := convert(e, elemval, options); err != nil {
 					return err
 				}

--- a/convert.go
+++ b/convert.go
@@ -261,15 +261,28 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 		retval.SetFloat(parsed)
 	case reflect.Slice:
 		elemtp := tp.Elem()
-
 		elemvalptr := reflect.New(elemtp)
 		elemval := reflect.Indirect(elemvalptr)
 
-		if err := convert(val, elemval, options); err != nil {
-			return err
-		}
+		delimiter := options.Get("delimiter")
+		if delimiter == "" {
+			if err := convert(val, elemval, options); err != nil {
+				return err
+			}
 
-		retval.Set(reflect.Append(retval, elemval))
+			retval.Set(reflect.Append(retval, elemval))
+		} else {
+			s := strings.Split(val, delimiter)
+			out := reflect.MakeSlice(tp, 0, 0)
+
+			for _, e := range s {
+				if err := convert(e, elemval, options); err != nil {
+					return err
+				}
+				out = reflect.Append(out, elemval)
+			}
+			retval.Set(out)
+		}
 	case reflect.Map:
 		keyValueDelimiter := options.Get("key-value-delimiter")
 		if keyValueDelimiter == "" {

--- a/convert_test.go
+++ b/convert_test.go
@@ -176,3 +176,41 @@ func TestConvertToMapWithDelimiter(t *testing.T) {
 
 	assertString(t, opts.StringStringMap["key"], "value")
 }
+
+func TestConvertToStringSliceWithDelimiter(t *testing.T) {
+	var opts = struct {
+		StringSlice []string `long:"string-slice" delimiter:","`
+	}{}
+
+	p := NewNamedParser("test", Default)
+	grp, _ := p.AddGroup("test group", "", &opts)
+	o := grp.Options()[0]
+
+	err := convert("a,b,c", o.value, o.tag)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+	expected := []string{"a", "b", "c"}
+	assertStringArray(t, opts.StringSlice, expected)
+}
+
+func TestConvertToIntSliceWithDelimiter(t *testing.T) {
+	var opts = struct {
+		IntSlice []int `long:"string-slice" delimiter:","`
+	}{}
+
+	p := NewNamedParser("test", Default)
+	grp, _ := p.AddGroup("test group", "", &opts)
+	o := grp.Options()[0]
+
+	err := convert("1,2,3", o.value, o.tag)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+	expected := []int{1, 2, 3}
+	assertIntArray(t, opts.IntSlice, expected)
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -196,6 +196,29 @@ func TestConvertToStringSliceWithDelimiter(t *testing.T) {
 	assertStringArray(t, opts.StringSlice, expected)
 }
 
+func TestConvertToNullSlice(t *testing.T) {
+	var opts = struct {
+		StringSlice []string `long:"string-slice" delimiter:","`
+	}{}
+
+	p := NewNamedParser("test", Default)
+	grp, _ := p.AddGroup("test group", "", &opts)
+	o := grp.Options()[0]
+
+	err := convert("", o.value, o.tag)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+	var expected []string
+
+	t.Log(expected, len(expected), expected == nil)
+	t.Log(opts.StringSlice, len(opts.StringSlice), opts.StringSlice == nil)
+
+	assertStringArray(t, opts.StringSlice, expected)
+}
+
 func TestConvertToIntSliceWithDelimiter(t *testing.T) {
 	var opts = struct {
 		IntSlice []int `long:"string-slice" delimiter:","`


### PR DESCRIPTION
Closes #245.
Missing some documentation (and tests?) and the ability to escape delimiters (as pointed out in [#248](https://github.com/jessevdk/go-flags/pull/252/files#r178428267)). 
In this case, should they be escaped if inside quoted strings, like in a CSV file, for example?

PS: the `assertTypeArray` functions could be made generic, I can create another PR if you think it would be helpful

Edit: unfortunately this creates a non-nil slice even when the argument is not used.