### PR TITLE
Add an interface for flag types that can provide default values

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -37,8 +37,8 @@ type ValueValidator interface {
 	IsValidValue(value string) error
 }
 
-// Defaulter is the interface implemented by types that can provide a dynamic
-// default value at runtime.
+// Defaulter is the interface implemented by types that can provide dynamic
+// default values at runtime.
 type Defaulter interface {
 	Default() ([]string, error)
 }

--- a/convert.go
+++ b/convert.go
@@ -37,6 +37,12 @@ type ValueValidator interface {
 	IsValidValue(value string) error
 }
 
+// Defaulter is the interface implemented by types that can provide a dynamic
+// default value at runtime.
+type Defaulter interface {
+	Default() []string
+}
+
 func getBase(options multiTag, base int) (int, error) {
 	sbase := options.Get("base")
 

--- a/convert.go
+++ b/convert.go
@@ -40,7 +40,7 @@ type ValueValidator interface {
 // Defaulter is the interface implemented by types that can provide a dynamic
 // default value at runtime.
 type Defaulter interface {
-	Default() []string
+	Default() ([]string, error)
 }
 
 func getBase(options multiTag, base int) (int, error) {

--- a/group.go
+++ b/group.go
@@ -314,7 +314,11 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		}
 
 		if defaulter, ok := option.value.Interface().(Defaulter); ok {
-			option.Default = defaulter.Default()
+			def, err := defaulter.Default()
+			if err != nil {
+				return err
+			}
+			option.Default = def
 		}
 
 		g.options = append(g.options, option)

--- a/group.go
+++ b/group.go
@@ -313,6 +313,10 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 				option.shortAndLongName())
 		}
 
+		if defaulter, ok := option.value.Interface().(Defaulter); ok {
+			option.Default = defaulter.Default()
+		}
+
 		g.options = append(g.options, option)
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -168,6 +168,25 @@ func TestNoDefaultsForBools(t *testing.T) {
 	}
 }
 
+func TestDynamicDefaults(t *testing.T) {
+	var opts struct {
+		DD DynamicDefault `short:"d"`
+	}
+	_, err := ParseArgs(&opts, []string{"test"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.DD != 42 {
+		t.Errorf("Dynamic default value not provided; expected 42 but was %d", opts.DD)
+	}
+}
+
+type DynamicDefault int
+
+func (dd DynamicDefault) Default() []string {
+	return []string{"42"}
+}
+
 func TestUnquoting(t *testing.T) {
 	var tests = []struct {
 		arg   string

--- a/parser_test.go
+++ b/parser_test.go
@@ -181,10 +181,30 @@ func TestDynamicDefaults(t *testing.T) {
 	}
 }
 
+func TestDynamicDefaultError(t *testing.T) {
+	var opts struct {
+		DD DynamicDefaultError `short:"d"`
+	}
+	_, err := ParseArgs(&opts, []string{"test"})
+	if err == nil {
+		t.Fatalf("Expected error, was none")
+	}
+	const expected = "couldn't provide default"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected error %q to contain substring %q", err, expected)
+	}
+}
+
 type DynamicDefault int
 
-func (dd DynamicDefault) Default() []string {
-	return []string{"42"}
+func (dd DynamicDefault) Default() ([]string, error) {
+	return []string{"42"}, nil
+}
+
+type DynamicDefaultError int
+
+func (dd DynamicDefaultError) Default() ([]string, error) {
+	return nil, errors.New("couldn't provide default")
 }
 
 func TestUnquoting(t *testing.T) {


### PR DESCRIPTION
A simple use case might be that you want a flag to have the value of `os.UserCacheDir()` and don't want to replicate its logic and/or deal with per-platform structs.

I suppose there's a chance that someone already has a type with this method signature which suddenly starts providing defaults. I think the chance is probably low, but there's no real way of avoiding that with Go's implicit interfaces.

Fixes #421 